### PR TITLE
Send graph storage options as part of the host configuration.

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -214,6 +214,7 @@ type HostConfig struct {
 	PublishAllPorts bool               // Should docker publish all exposed port for the container
 	ReadonlyRootfs  bool               // Is the container root filesystem in read-only
 	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
+	StorageOpt      []string           // Graph storage options per container
 	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode            // UTS namespace to use for the container
 	ShmSize         int64              // Total shm memory usage


### PR DESCRIPTION
We're going to allow to send options to the storage drivers with this.

See https://github.com/docker/docker/pull/19123 for more information.

Signed-off-by: David Calavera <david.calavera@gmail.com>