### PR TITLE
Add authentication to the docker client library

### DIFF
--- a/client/authn/authn.go
+++ b/client/authn/authn.go
@@ -1,0 +1,63 @@
+package authn
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Logger is an interface for debug and logging callbacks.
+type Logger interface {
+	Debug(formatted string)
+	Info(formatted string)
+	Error(formatted string)
+}
+
+// ignorelogs is an implementation of Logger that ignores everything it's
+// passed.  We use it as the default set of logging callbacks if none are set.
+type ignorelogs struct {
+}
+
+func (l *ignorelogs) Debug(formatted string) {}
+func (l *ignorelogs) Info(formatted string)  {}
+func (l *ignorelogs) Error(formatted string) {}
+
+// authResponder is an interface that wraps the scheme,
+// authRespond, and authCompleted methods.
+//
+// At initialization time, an implementation of authResponder should register
+// itself by calling registerAuthResponder.
+type authResponder interface {
+	// Scheme should return the name of the authorization scheme for which
+	// the responder should be called.
+	scheme() string
+	// authRespond, given the authentication header value associated with
+	// the scheme that it implements, can decide if the request should be
+	// retried.  If it returns true, then the request is retransmitted to
+	// the server, presumably because it has added an authentication header
+	// which it believes the server will accept.
+	authRespond(challenge string, req *http.Request) (bool, error)
+	// AuthCompleted, given a (possibly empty) WWW-Authenticate header and
+	// a successful response, should decide if the server's reply should be
+	// accepted.
+	authCompleted(challenge string, resp *http.Response) (bool, error)
+}
+
+// authResponderCreators functions create a new authResponder.
+var authResponderCreators = []func(logger Logger, authers []interface{}) authResponder{}
+
+// Run through all of the registered responder creators and build a map of
+// names-to-responder-instances.
+func createAuthResponders(logger Logger, authers []interface{}) map[string]authResponder {
+	if logger == nil {
+		logger = &ignorelogs{}
+	}
+	ars := make(map[string]authResponder)
+	for _, arc := range authResponderCreators {
+		responder := arc(logger, authers)
+		if responder != nil {
+			scheme := strings.ToLower(responder.scheme())
+			ars[scheme] = responder
+		}
+	}
+	return ars
+}

--- a/client/authn/basic.go
+++ b/client/authn/basic.go
@@ -1,0 +1,78 @@
+package authn
+
+import (
+	"errors"
+	"net/http"
+)
+
+// BasicAuther is an interface which a caller may provide for obtaining a user
+// name and password to use when attempting Basic authentication with a server.
+type BasicAuther interface {
+	GetBasicAuth(realm string) (user, password string, err error)
+}
+
+type basic struct {
+	logger             Logger
+	username, password string
+	auther             BasicAuther
+}
+
+func (b *basic) scheme() string {
+	return "Basic"
+}
+
+func (b *basic) authRespond(challenge string, req *http.Request) (result bool, err error) {
+	if b.username != "" && b.password != "" {
+		b.logger.Debug("using previously-supplied Basic username and password")
+		req.SetBasicAuth(b.username, b.password)
+		return true, nil
+	}
+
+	if b.auther == nil {
+		b.logger.Debug("failed to obtain user name and password for Basic auth")
+		return false, nil
+	}
+
+	realm, _ := getParameter(challenge, "realm")
+	username, password, err := b.auther.GetBasicAuth(realm)
+	if err != nil {
+		return false, err
+	}
+	if username == "" {
+		b.logger.Debug("failed to obtain user name for Basic auth")
+		return false, nil
+	}
+	if password == "" {
+		b.logger.Debug("failed to obtain password for Basic auth")
+		return false, nil
+	}
+
+	b.username = username
+	b.password = password
+	req.SetBasicAuth(b.username, b.password)
+	return true, nil
+}
+
+func (b *basic) authCompleted(challenge string, resp *http.Response) (result bool, err error) {
+	if challenge == "" {
+		return true, nil
+	}
+	return false, errors.New("Error: unexpected WWW-Authenticate header in server response")
+}
+
+func createBasic(logger Logger, authers []interface{}) authResponder {
+	var ba BasicAuther
+	for _, auther := range authers {
+		if b, ok := auther.(BasicAuther); ok {
+			ba = b
+			if ba != nil {
+				break
+			}
+		}
+	}
+	return &basic{logger: logger, auther: ba}
+}
+
+func init() {
+	authResponderCreators = append(authResponderCreators, createBasic)
+}

--- a/client/authn/bearer.go
+++ b/client/authn/bearer.go
@@ -1,0 +1,70 @@
+package authn
+
+import (
+	"errors"
+	"net/http"
+)
+
+// BearerAuther is an interface which a caller may provide for obtaining a
+// token to use in attempting Bearer authentication with a server.
+type BearerAuther interface {
+	GetBearerAuth(challenge string) (token string, err error)
+}
+
+type bearer struct {
+	logger Logger
+	token  string
+	auther BearerAuther
+}
+
+func (b *bearer) scheme() string {
+	return "Bearer"
+}
+
+func (b *bearer) authRespond(challenge string, req *http.Request) (result bool, err error) {
+	token := b.token
+	if token != "" {
+		b.logger.Debug("using previously-supplied Bearer token")
+		req.Header.Add("Authorization", "Bearer "+token)
+		return true, nil
+	}
+	if b.auther == nil {
+		b.logger.Debug("failed to obtain token for Bearer auth")
+		return false, nil
+	}
+	token, err = b.auther.GetBearerAuth(challenge)
+	if err != nil {
+		return false, err
+	}
+	if token == "" {
+		b.logger.Debug("Bearer token not supplied")
+		return false, nil
+	}
+	b.token = token
+	req.Header.Add("Authorization", "Bearer "+b.token)
+	return true, nil
+}
+
+func (b *bearer) authCompleted(challenge string, resp *http.Response) (result bool, err error) {
+	if challenge == "" {
+		return true, nil
+	}
+	return false, errors.New("Error: unexpected WWW-Authenticate header in server response")
+}
+
+func createBearer(logger Logger, authers []interface{}) authResponder {
+	var ba BearerAuther
+	for _, auther := range authers {
+		if b, ok := auther.(BearerAuther); ok {
+			ba = b
+			if ba != nil {
+				break
+			}
+		}
+	}
+	return &bearer{logger: logger, auther: ba}
+}
+
+func init() {
+	authResponderCreators = append(authResponderCreators, createBearer)
+}

--- a/client/authn/middleware.go
+++ b/client/authn/middleware.go
@@ -1,0 +1,109 @@
+package authn
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Middleware returns a function which wraps the passed-in Do()-style function,
+// handling any "unauthorized" errors which it returns by retrying the same
+// request with authentication.
+func Middleware(logger Logger, authers ...interface{}) func(func(req *http.Request) (resp *http.Response, err error)) func(req *http.Request) (resp *http.Response, err error) {
+	authResponders := createAuthResponders(logger, authers)
+	return func(doer func(req *http.Request) (resp *http.Response, err error)) func(req *http.Request) (resp *http.Response, err error) {
+		return func(req *http.Request) (resp *http.Response, err error) {
+			// We may have to issue the request multiple times, so
+			// we need to be able to rewind and recover everything
+			// we've sent.
+			rewinder := makeRewinder(req.Body)
+			req.Body = rewinder
+			resp, err = doer(req)
+			// If we previously tried to authenticate, or this
+			// isn't an authentication-required error, we're done.
+			if req.Header.Get("Authorization") != "" || err != nil || resp.StatusCode != http.StatusUnauthorized {
+				return resp, err
+			}
+			// Handle Unauthorized errors by attempting to
+			// authenticate, possibly doing so over multiple round
+			// trips.
+			scheme := ""
+			reqheader := http.CanonicalHeaderKey("Authorization")
+			respheader := http.CanonicalHeaderKey("WWW-Authenticate")
+			for err == nil && resp.StatusCode == http.StatusUnauthorized {
+				authnHeaders := req.Header[reqheader]
+				triedAuthnPreviously := authnHeaders != nil && len(authnHeaders) > 0
+				retryWithUpdatedAuthn := false
+				ah := resp.Header[respheader]
+				for _, challenge := range ah {
+					tokens := strings.Split(strings.Replace(challenge, "\t", " ", -1), " ")
+					responder, ok := authResponders[strings.ToLower(tokens[0])]
+					if !ok {
+						logger.Debug(fmt.Sprintf("no support for authentication scheme \"%s\"", tokens[0]))
+						continue
+					}
+					retryWithUpdatedAuthn, err = responder.authRespond(challenge, req)
+					if retryWithUpdatedAuthn {
+						logger.Debug(fmt.Sprintf("handler for \"%s\" produced data", tokens[0]))
+						scheme = strings.ToLower(tokens[0])
+						break
+					}
+					if err != nil {
+						logger.Debug(fmt.Sprintf("%v. handler for \"%s\" failed to produce data", err, tokens[0]))
+					} else {
+						logger.Debug(fmt.Sprintf("handler for \"%s\" failed to produce data", tokens[0]))
+					}
+				}
+				if len(ah) == 0 {
+					if triedAuthnPreviously {
+						err = fmt.Errorf("Failed to authenticate to docker daemon")
+					} else {
+						err = errors.New("Failed to authenticate to docker daemon; server offered no authentication methods")
+					}
+					break
+				} else if err != nil {
+					err = fmt.Errorf("%v. Failed to authenticate to docker daemon", err)
+					break
+				} else if !retryWithUpdatedAuthn {
+					err = errors.New("Unable to attempt to authenticate to docker daemon")
+					break
+				} else {
+					ioutil.ReadAll(resp.Body)
+					resp.Body.Close()
+					rewinder.Rewind()
+					req.Body = ioutil.NopCloser(rewinder)
+					resp, err = doer(req)
+				}
+			}
+			if err == nil && resp.StatusCode != http.StatusUnauthorized {
+				completed := false
+				tokens := []string{}
+				ah := resp.Header[respheader]
+				for _, challenge := range ah {
+					tokens = strings.Split(strings.Replace(challenge, "\t", " ", -1), " ")
+					if strings.ToLower(tokens[0]) == scheme {
+						break
+					}
+				}
+				if len(tokens) == 0 || strings.ToLower(tokens[0]) == scheme {
+					responder := authResponders[scheme]
+					completed, err = responder.authCompleted(strings.Join(tokens, " "), resp)
+					if completed {
+						logger.Debug(fmt.Sprintf("handler for \"%s\" succeeded", scheme))
+					} else {
+						logger.Debug(fmt.Sprintf("handler for \"%s\" failed", scheme))
+					}
+				} else if len(ah) == 0 {
+					logger.Debug("No authentication header in final server response")
+				} else if err != nil {
+					err = fmt.Errorf("%v. Unable to authenticate docker daemon", err)
+				} else if !completed {
+					err = fmt.Errorf("Unable to authenticate docker daemon")
+				}
+			}
+			return resp, err
+		}
+	}
+}

--- a/client/authn/middleware.go
+++ b/client/authn/middleware.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+// NegotiateAuther is an interface which a caller may provide for telling us if
+// we should attempt Negotiate authentication with a server.
+type NegotiateAuther interface {
+	GetNegotiateAuth() bool
+}
+
 // Middleware returns a function which wraps the passed-in Do()-style function,
 // handling any "unauthorized" errors which it returns by retrying the same
 // request with authentication.

--- a/client/authn/negotiate_gssapi.go
+++ b/client/authn/negotiate_gssapi.go
@@ -1,0 +1,177 @@
+// +build linux,cgo,!static_build,gssapi
+
+package authn
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"unsafe"
+)
+
+// #cgo pkg-config: krb5-gssapi
+// #include <sys/types.h>
+// #include <stdlib.h>
+// #include <gssapi/gssapi.h>
+// gss_OID_desc SpnegoOid = {
+//     .length = 6,
+//     .elements = "\053\006\001\005\005\002"
+// };
+import "C"
+
+type negotiate struct {
+	logger   Logger
+	major    C.OM_uint32
+	ctx      C.gss_ctx_id_t
+	hostname string
+}
+
+func getErrorDesc(major, minor C.OM_uint32, mech C.gss_OID) string {
+	var mj, mn C.gss_buffer_desc
+	var str string
+	var cm, mc C.OM_uint32
+
+	major = C.gss_display_status(&cm, major, C.GSS_C_GSS_CODE, nil, &mc, &mj)
+	if major == 0 && mj.value != nil && mj.length > 0 {
+		str = string(C.GoBytes(mj.value, C.int(mj.length)))
+		C.gss_release_buffer(nil, &mj)
+	}
+	if minor != 0 {
+		major = C.gss_display_status(&cm, minor, C.GSS_C_MECH_CODE, mech, &mc, &mn)
+		if major == 0 && mn.value != nil && mn.length > 0 {
+			if str != "" {
+				str = str + ": " + string(C.GoBytes(mn.value, C.int(mn.length)))
+			} else {
+				str = "?: " + string(C.GoBytes(mn.value, C.int(mn.length)))
+			}
+			C.gss_release_buffer(nil, &mn)
+		}
+	}
+	return str
+}
+
+func (n *negotiate) scheme() string {
+	return "Negotiate"
+}
+
+func (n *negotiate) authStep(challenge string, req *http.Request) (result bool, err error) {
+	var itoken, otoken, namebuf C.gss_buffer_desc
+	var itokenptr *C.gss_buffer_desc
+	var minor, lifetime, flags C.OM_uint32
+	var name C.gss_name_t
+	var mech C.gss_OID
+
+	fields := strings.SplitN(strings.Replace(challenge, "\t", " ", -1), " ", 2)
+	if strings.ToLower(fields[0]) == "negotiate" {
+		// Decode any incoming token, and set a pointer to it, if there is one.
+		if len(fields) > 1 {
+			token, err := base64.StdEncoding.DecodeString(fields[1])
+			if err != nil {
+				n.logger.Error(fmt.Sprintf("error decoding Negotiate token from server: \"%s\"", fields[1]))
+				return false, err
+			}
+			n.logger.Debug(fmt.Sprintf("gssapi: received token \"%s\"", fields[1]))
+			itoken.value = unsafe.Pointer(&token[0])
+			itoken.length = C.size_t(len(token))
+			itokenptr = &itoken
+		}
+		// Work out the server's GSSAPI name.
+		service := "HTTP@" + n.hostname
+		n.logger.Debug(fmt.Sprintf("gssapi: using service name \"%s\"", service))
+		// Import the name.
+		namebuf.value = unsafe.Pointer(C.CString(service))
+		defer C.free(namebuf.value)
+		namebuf.length = C.size_t(len(service))
+		mech = &C.SpnegoOid
+		n.major = C.gss_import_name(&minor, &namebuf, C.GSS_C_NT_HOSTBASED_SERVICE, &name)
+		if name != nil {
+			defer C.gss_release_name(&minor, &name)
+		}
+		if n.major != C.GSS_S_COMPLETE {
+			n.logger.Info(fmt.Sprintf("error importing server name (%s), not attempting Negotiate auth", getErrorDesc(n.major, minor, nil)))
+			return false, nil
+		}
+		lifetime = C.GSS_C_INDEFINITE
+		// Call the initiation function, maybe with data we got from the server.
+		if itokenptr != nil {
+			n.logger.Debug(fmt.Sprintf("gssapi: reading token (%d bytes)", itokenptr.length))
+		}
+		n.major = C.gss_init_sec_context(&minor, nil, &n.ctx, name, mech, flags, lifetime, nil, itokenptr, nil, &otoken, nil, nil)
+		if otoken.length > 0 {
+			defer C.gss_release_buffer(&minor, &otoken)
+		}
+		// Check for complete or partial success.
+		if n.major != C.GSS_S_COMPLETE && n.major != C.GSS_S_CONTINUE_NEEDED {
+			if itokenptr != nil {
+				n.logger.Info(fmt.Sprintf("error generating GSSAPI session initiation token (%s), not attempting Negotiate auth", getErrorDesc(n.major, minor, nil)))
+			} else {
+				n.logger.Debug(fmt.Sprintf("error generating GSSAPI session initiation token (%s), not attempting Negotiate auth", getErrorDesc(n.major, minor, nil)))
+			}
+			return false, nil
+		}
+		// Format data for the server.
+		if otoken.length > 0 {
+			if req == nil {
+				n.logger.Error("synchronization error: got unexpected Negotiate token to send to server")
+				return false, nil
+			}
+			response := C.GoBytes(otoken.value, C.int(otoken.length))
+			token := base64.StdEncoding.EncodeToString(response)
+			req.Header.Add("Authorization", "Negotiate "+token)
+			n.logger.Debug(fmt.Sprintf("gssapi: generated token \"%s\"", token))
+		}
+		if n.major == C.GSS_S_CONTINUE_NEEDED {
+			n.logger.Debug("gssapi: continue needed")
+		} else {
+			n.logger.Debug("gssapi: complete")
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (n *negotiate) authRespond(challenge string, req *http.Request) (result bool, err error) {
+	if n.hostname == "" {
+		serverhost := req.Host
+		if serverhost == "" {
+			serverhost = req.URL.Host
+		}
+		if serverhost[0] == os.PathSeparator {
+			serverhost, _ = os.Hostname()
+		}
+		sep := strings.LastIndex(serverhost, ":")
+		if sep > -1 && sep > strings.LastIndex(serverhost, "]") {
+			serverhost = serverhost[:sep]
+		}
+		n.hostname = serverhost
+	}
+	return n.authStep(challenge, req)
+}
+
+func (n *negotiate) authCompleted(challenge string, resp *http.Response) (completed bool, err error) {
+	var minor C.OM_uint32
+	completed, err = n.authStep(challenge, nil)
+	// Reset state, in case we need to do all of this again.
+	if n.ctx != nil {
+		C.gss_delete_sec_context(&minor, &n.ctx, nil)
+		n.ctx = nil
+	}
+	return
+}
+
+func createNegotiate(logger Logger, authers []interface{}) authResponder {
+	for _, auther := range authers {
+		if b, ok := auther.(NegotiateAuther); ok {
+			if b != nil && b.GetNegotiateAuth() {
+				return &negotiate{logger: logger}
+			}
+		}
+	}
+	return nil
+}
+
+func init() {
+	authResponderCreators = append(authResponderCreators, createNegotiate)
+}

--- a/client/authn/param.go
+++ b/client/authn/param.go
@@ -1,0 +1,106 @@
+package authn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// strspn counts the number of initial characters in s which are contained in
+// spn, returning a value in the range of [0,len(s)].
+func strspn(s, spn string) int {
+	ret := strings.IndexFunc(s, func(r rune) bool { return strings.IndexRune(spn, r) == -1 })
+	if ret == -1 {
+		ret = len(s)
+	}
+	return ret
+}
+
+// tokenize splits an authentication challenge header value into a slice of
+// strings, the first being the challenge itself, and each subsequent entry
+// being a key/value pair, with quoting removed.  This isn't strictly in
+// conformance with the RFCs, which allow multiple such sequences to be
+// included in a single header line, but the Docker daemon doesn't do that, so
+// we make the assumption.
+func tokenize(header string) (challenge []string, err error) {
+	token68 := "-._~+/0123456789" +
+		"abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	var tokens []string
+	var current int
+	// build an intermediate list of unquoted items
+	for current < len(header) {
+		if len(tokens) > 0 && header[current] == '"' {
+			// quoted string, can't be the first token
+			quoted := ""
+			end := current + 1
+			for end < len(header) {
+				if header[end] == '\\' {
+					if end+1 < len(header) {
+						end++
+						quoted = quoted + string(header[end])
+					}
+					end++
+					continue
+				}
+				if header[end] == '"' {
+					end++
+					break
+				}
+				quoted = quoted + string(header[end])
+				end++
+			}
+			tokens = append(tokens, quoted)
+			current = end
+			continue
+		}
+		if strings.IndexAny(string(header[current]), token68) != -1 {
+			// not a quoted string
+			end := current + strspn(header[current:], token68)
+			tokens = append(tokens, header[current:end])
+			current = end
+			continue
+		}
+		if header[current] == '=' {
+			// treat "=" specifically
+			tokens = append(tokens, string(header[current]))
+			current++
+			continue
+		}
+		if strings.IndexAny(string(header[current]), "\t ,\r\n") != -1 {
+			// treat all whitespace as optional
+			current++
+			continue
+		}
+		return nil, fmt.Errorf("Error parsing header %v: unexpected token at %s", header, header[current:])
+	}
+	// enforce single token + optional key=value tuples as the format
+	for i := 0; i < len(tokens); i++ {
+		if (tokens[i] == "=") != (i%3 == 2) {
+			return nil, fmt.Errorf("Error parsing token list %v: unexpected token %s", tokens, tokens[i])
+		}
+	}
+	if len(tokens)%3 != 1 {
+		return nil, fmt.Errorf("Error parsing token list %v: unexpected length", tokens)
+	}
+	// reformat as single token + key=value tokens
+	challenge = append(challenge, tokens[0])
+	for i := 1; i+2 < len(tokens); i += 3 {
+		challenge = append(challenge, strings.ToLower(tokens[i])+"="+tokens[i+2])
+	}
+	return challenge, nil
+}
+
+// getParameter reads a particular parameter from an authentication challenge,
+// returning an error if it runs into trouble parsing the challenge line
+func getParameter(header string, parameter string) (string, error) {
+	tokens, err := tokenize(header)
+	if err != nil {
+		return "", err
+	}
+	for _, token := range tokens {
+		if strings.HasPrefix(token, strings.ToLower(parameter)+"=") {
+			return token[len(parameter)+1:], nil
+		}
+	}
+	return "", nil
+}

--- a/client/authn/param_test.go
+++ b/client/authn/param_test.go
@@ -1,0 +1,73 @@
+package authn
+
+import (
+	"testing"
+)
+
+func TestStrspn(t *testing.T) {
+	type strspntest struct {
+		input, chars string
+		length       int
+	}
+	tests := []strspntest{
+		{"abcdefg", "bdca", 4},
+		{"abcdefg", "efg", 0},
+		{"abcdefg", "hijkl", 0},
+		{"abcdefg", "0123", 0},
+		{"abcdefg", "aaaa", 1},
+		{"abcdefg", "fedcba", 6},
+		{"abcdefg", "fedghijklmcba", 7},
+	}
+	for _, test := range tests {
+		if strspn(test.input, test.chars) != test.length {
+			t.Fatalf(`strspn("%s","%s") != %d`, test.input, test.chars, test.length)
+		}
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	type tokenizeTest struct {
+		input  string
+		output []string
+		err    string
+	}
+	tests := []tokenizeTest{
+		{"Bearer", []string{"Bearer"}, ""},
+		{`Basic realm="foo"`, []string{"Basic", "realm=foo"}, ""},
+		{`Basic realm="foo", chars=blah`, []string{"Basic", "realm=foo", "chars=blah"}, ""},
+	}
+	for _, test := range tests {
+		_, err := tokenize(test.input)
+		if err != nil {
+			if err.Error() != test.err {
+				t.Fatalf("Unexpected error tokenizing %v: %v", test.input, err)
+			}
+		} else {
+			if test.err != "" {
+				t.Fatalf("Unexpected non-error tokenizing %v: expected %v", test.input, test.err)
+			}
+		}
+	}
+}
+
+func TestGetParameter(t *testing.T) {
+	type getParameterTest struct {
+		input     string
+		parameter string
+		value     string
+	}
+	tests := []getParameterTest{
+		{`Basic realm="foo"`, "realm", "foo"},
+		{`Basic realm="foo", chars=blah`, "realm", "foo"},
+		{`Basic realm="foo", chars=blah`, "chars", "blah"},
+	}
+	for _, test := range tests {
+		value, err := getParameter(test.input, test.parameter)
+		if err != nil {
+			t.Fatalf(`Got error %v instead of "%s" from "%s"["%s"]`, err, test.value, test.input, test.parameter)
+		}
+		if value != test.value {
+			t.Fatalf(`Got "%s" instead of "%s" from "%s"["%s"]`, value, test.value, test.input, test.parameter)
+		}
+	}
+}

--- a/client/authn/rewind.go
+++ b/client/authn/rewind.go
@@ -1,0 +1,65 @@
+package authn
+
+import (
+	"bytes"
+	"io"
+)
+
+// Rewinder is a wrapper for an io.ReadCloser() that adds the ability to rewind
+// the incoming data stream.  It does this by caching everything that's read
+// from it, and starting over when the Rewind() method is called, answering
+// read requests from its cache until the cache is exhausted, and then pulling
+// "live" data from the Reader.
+type Rewinder interface {
+	Rewind()
+	io.ReadCloser
+}
+
+type rewinder struct {
+	buffer bytes.Buffer
+	reader io.Reader
+	read   int
+}
+
+// Rewind rewinds the input stream in the object, so that the next Read attempt
+// will return data starting at the first byte that was ever read.
+func (r *rewinder) Rewind() {
+	r.read = 0
+}
+
+// Close fakes closing the reader.
+func (r *rewinder) Close() error {
+	r.Rewind()
+	return nil
+}
+
+func (r *rewinder) Read(p []byte) (n int, err error) {
+	// If we have enough data to satisfy the read attempt from the buffer,
+	// just return the data and increment our read offset.
+	if r.read+len(p) < r.buffer.Len() {
+		n, err = bytes.NewReader(r.buffer.Bytes()[r.read:]).Read(p)
+		if n > 0 {
+			r.read += n
+		}
+		return n, err
+	}
+	// We don't have enough data.  Read what we've already buffered first.
+	n2, err2 := bytes.NewReader(r.buffer.Bytes()[r.read:]).Read(p)
+	if n2 > 0 {
+		r.read += n2
+	}
+	if err2 != nil && err2 != io.EOF {
+		return n2, err2
+	}
+	// Try to read some more.
+	n3, err3 := r.reader.Read(p[n2:])
+	if n3 > 0 {
+		r.buffer.Write(p[n2 : n2+n3])
+		r.read += n3
+	}
+	return n2 + n3, err3
+}
+
+func makeRewinder(reader io.Reader) Rewinder {
+	return &rewinder{reader: reader}
+}

--- a/client/authn/rewind_test.go
+++ b/client/authn/rewind_test.go
@@ -1,0 +1,38 @@
+package authn
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestRewinder(t *testing.T) {
+	s := "abcdefghijklmnopqrstuvwxyz"
+	rewinder := makeRewinder(bytes.NewBufferString(s))
+	for i := 1; i < len(s); i++ {
+		b := bytes.NewBuffer([]byte{})
+		j := 0
+		for j < len(s) {
+			p := make([]byte, i)
+			n, err := rewinder.Read(p)
+			b.Write(p[:n])
+			j += n
+			if n < len(p) {
+				if err == io.EOF {
+					break
+				}
+				t.Fatalf("Unexpected read error at %d (%d): %v", i, j, err)
+				return
+			}
+		}
+		if j != b.Len() || j == 0 {
+			t.Fatalf("Unexpected length %d (expected %d)", j, b.Len())
+			return
+		}
+		if !bytes.Equal(b.Bytes()[:j], bytes.NewBufferString(s).Bytes()[:j]) {
+			t.Fatalf("Mismatch on data pass %d/%d)", i, j)
+			return
+		}
+		rewinder.Rewind()
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,10 @@ type Client struct {
 	version string
 	// custom http headers configured by users
 	customHTTPHeaders map[string]string
+	// logging callbacks, if we're meant to log messages
+	logger Logger
+	// authentication-related callbacks
+	authers []interface{}
 }
 
 // NewEnvClient initializes a new API client based on environment variables.
@@ -95,6 +99,47 @@ func NewClient(host string, version string, transport *http.Transport, httpHeade
 		version:           version,
 		customHTTPHeaders: httpHeaders,
 	}, nil
+}
+
+// SetAuth sets callbacks that the library can use to obtain information which
+// is needs in order to authenticate to the server.
+func (cli *Client) SetAuth(m ...interface{}) {
+	cli.authers = m
+}
+
+// SetLogger sets a callback that the client can use to log debugging
+// messages.  The callback should not treat messages which are passed to it as
+// format specifiers.
+func (cli *Client) SetLogger(logger Logger) {
+	cli.logger = logger
+}
+
+// debugf passes debugging messages to the callback, if one is set
+func (cli *Client) debugf(format string, args ...interface{}) {
+	if cli.logger != nil {
+		cli.logger.Debug(fmt.Sprintf(format, args...))
+	}
+}
+
+// debug passes a debugging message to the callback, if one is set
+func (cli *Client) debug(formatted string) {
+	if cli.logger != nil {
+		cli.logger.Debug(formatted)
+	}
+}
+
+// infof passes informational messages to the callback, if one is set
+func (cli *Client) infof(format string, args ...interface{}) {
+	if cli.logger != nil {
+		cli.logger.Info(fmt.Sprintf(format, args...))
+	}
+}
+
+// errorf passes error messages to the right callback, if one is set
+func (cli *Client) errorf(format string, args ...interface{}) {
+	if cli.logger != nil {
+		cli.logger.Error(fmt.Sprintf(format, args...))
+	}
 }
 
 // getAPIPath returns the versioned request path to call the api.

--- a/client/cookies.go
+++ b/client/cookies.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"net/http"
+)
+
+// Wrap the call, or not, with cookie handling.  An http.Client would handle
+// this for us if we passed in a cookie jar when we initialized it, but we'd
+// still have to do the work for httputil.ClientConn, so we don't set it for
+// elsewhere http.Clients to avoid duplicating cookies in requests.
+func (cli *Client) cookieMiddleware(doer func(*http.Request) (*http.Response, error)) func(*http.Request) (*http.Response, error) {
+	var jar http.CookieJar
+
+	for _, auther := range cli.authers {
+		if c, ok := auther.(CookieJarGetter); ok {
+			jar = c.GetCookieJar()
+			if jar != nil {
+				break
+			}
+		}
+	}
+	if jar == nil {
+		return doer
+	}
+	return func(req *http.Request) (resp *http.Response, err error) {
+		req.URL.Scheme = cli.scheme
+		for _, cookie := range jar.Cookies(req.URL) {
+			req.AddCookie(cookie)
+		}
+		resp, err = doer(req)
+		if resp != nil {
+			if cookies := resp.Cookies(); cookies != nil {
+				jar.SetCookies(req.URL, cookies)
+			}
+		}
+		return resp, err
+	}
+}

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
@@ -66,7 +67,15 @@ func (cli *Client) postHijacked(path string, query url.Values, body interface{},
 	defer clientconn.Close()
 
 	// Server hijacks the connection, error 'connection closed' expected
-	clientconn.Do(req)
+	resp, err := cli.doWithMiddlewares(clientconn.Do)(req)
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		cli.debugf("[hijack] Error %d hijacking", resp.StatusCode)
+		if err != nil {
+			return types.HijackedResponse{}, err
+		}
+		return types.HijackedResponse{}, fmt.Errorf("Error hijacking connection to the Docker daemon (expected status %d, got %d)", http.StatusSwitchingProtocols, resp.StatusCode)
+	}
 
 	rwc, br := clientconn.Hijack()
 

--- a/client/interface.go
+++ b/client/interface.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"io"
+	"net/http"
 
+	"github.com/docker/engine-api/client/authn"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
@@ -66,10 +68,23 @@ type APIClient interface {
 	NetworkRemove(networkID string) error
 	RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error)
 	ServerVersion() (types.Version, error)
+	SetAuth(m ...interface{})
+	SetLogger(logger Logger)
 	VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(volumeID string) (types.Volume, error)
 	VolumeList(filter filters.Args) (types.VolumesListResponse, error)
 	VolumeRemove(volumeID string) error
+}
+
+// Logger is an interface for debug and logging callbacks.
+type Logger interface {
+	authn.Logger
+}
+
+// CookieJarGetter is an interface which a caller may provide for us if we
+// should be storing and using cookies which are set by a server.
+type CookieJarGetter interface {
+	GetCookieJar() http.CookieJar
 }
 
 // Ensure that Client always implements APIClient.

--- a/client/middleware.go
+++ b/client/middleware.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/http"
+
+	"github.com/docker/engine-api/client/authn"
+)
+
+func (cli *Client) doWithMiddlewares(d func(*http.Request) (*http.Response, error)) func(*http.Request) (*http.Response, error) {
+	middlewares := []func(func(*http.Request) (*http.Response, error)) func(*http.Request) (*http.Response, error){
+		cli.cookieMiddleware,
+		authn.Middleware(cli.logger, cli.authers...),
+	}
+	for _, m := range middlewares {
+		d = m(d)
+	}
+	return d
+}

--- a/client/request.go
+++ b/client/request.go
@@ -88,7 +88,7 @@ func (cli *Client) sendClientRequest(method, path string, query url.Values, body
 		req.Header.Set("Content-Type", "text/plain")
 	}
 
-	resp, err := cli.httpClient.Do(req)
+	resp, err := cli.doWithMiddlewares(cli.httpClient.Do)(req)
 	if resp != nil {
 		serverResp.statusCode = resp.StatusCode
 	}


### PR DESCRIPTION
These are the client API library changes from https://github.com/docker/docker/pull/18514 which would now be made here: the client learns to use cookies, to use supplied callbacks to obtain user names, passwords, and tokens to use for Basic and Bearer authentication, and to attempt Negotiate authentication if it's been enabled at run-time.