### PR TITLE
Add a specific config for the update command

### DIFF
--- a/client/container_update.go
+++ b/client/container_update.go
@@ -5,8 +5,8 @@ import (
 )
 
 // ContainerUpdate updates resources of a container
-func (cli *Client) ContainerUpdate(containerID string, hostConfig container.HostConfig) error {
-	resp, err := cli.post("/containers/"+containerID+"/update", nil, hostConfig, nil)
+func (cli *Client) ContainerUpdate(containerID string, updateConfig container.UpdateConfig) error {
+	resp, err := cli.post("/containers/"+containerID+"/update", nil, updateConfig, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -184,6 +184,13 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 }
 
+// UpdateConfig holds the mutable attributes of a Container.
+// Those attributes can be updated at runtime.
+type UpdateConfig struct {
+	// Contains container's resources (cgroups, ulimits)
+	Resources
+}
+
 // HostConfig the non-portable Config structure of a container.
 // Here, "non-portable" means "dependent of the host we are running on".
 // Portable information *should* appear in Config.


### PR DESCRIPTION
This is related to docker/docker#19104.

> This is a proposal for #18957, to reduce what we send to the update endpoint. This also make it clear what is mutable in the container, and untie it from Config/HostConfig. It is still easy to add more attributes
>
> This allows use to control more what is or is not mutable in a container and remove the use of the internal HostConfig struct to be used 🐳.

/cc @calavera @tiborvass

Signed-off-by: Vincent Demeester <vincent@sbr.pm>