### PR TITLE
Adding link (local alias) config in endpointsettings

### DIFF
--- a/types/network/network.go
+++ b/types/network/network.go
@@ -30,6 +30,7 @@ type EndpointIPAMConfig struct {
 type EndpointSettings struct {
 	// Configurations
 	IPAMConfig *EndpointIPAMConfig
+	Links      []string
 	// Operational data
 	EndpointID          string
 	Gateway             string


### PR DESCRIPTION
Adding the alias fields in engine-api for the upcoming local alias feature (via link)

Signed-off-by: Madhu Venugopal <madhu@docker.com>