### PR TITLE
Change OomKillDisable to be pointer

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -180,7 +180,7 @@ type Resources struct {
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
-	OomKillDisable       bool            // Whether to disable OOM Killer or not
+	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 }


### PR DESCRIPTION
It's like `MemorySwappiness`, the default value has specific
meaning (default false means enable oom kill).

We need to change it to pointer so we can update it after
container is created.

Part of: https://github.com/docker/docker/pull/19014

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>