### PR TITLE
Adding global alias config fields in endpointsettings

### DIFF
--- a/types/network/network.go
+++ b/types/network/network.go
@@ -32,6 +32,7 @@ type EndpointSettings struct {
 	// Configurations
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
+	Aliases    []string
 	// Operational data
 	NetworkID           string
 	EndpointID          string


### PR DESCRIPTION
@calavera @tiborvass as discussed, this brings in the fields required to support global alias.
The e2e functionality including integration with docker and libnetwork is currently here : 
https://github.com/mavenugo/docker/commits/alias_3

Once this PR is merged, I will push the subsequent PR in docker/docker for any discussion.

cc @dnephin 

Signed-off-by: Madhu Venugopal <madhu@docker.com>