### PR TITLE
an option to disconnect an endpoint from a network forcefully

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -60,7 +60,7 @@ type APIClient interface {
 	Info() (types.Info, error)
 	NetworkConnect(networkID, containerID string, config *network.EndpointSettings) error
 	NetworkCreate(options types.NetworkCreate) (types.NetworkCreateResponse, error)
-	NetworkDisconnect(networkID, containerID string) error
+	NetworkDisconnect(networkID, containerID string, force bool) error
 	NetworkInspect(networkID string) (types.NetworkResource, error)
 	NetworkList(options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(networkID string) error

--- a/client/network.go
+++ b/client/network.go
@@ -42,9 +42,9 @@ func (cli *Client) NetworkConnect(networkID, containerID string, config *network
 }
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
-func (cli *Client) NetworkDisconnect(networkID, containerID string) error {
-	nc := types.NetworkConnect{Container: containerID}
-	resp, err := cli.post("/networks/"+networkID+"/disconnect", nil, nc, nil)
+func (cli *Client) NetworkDisconnect(networkID, containerID string, force bool) error {
+	nd := types.NetworkDisconnect{Container: containerID, Force: force}
+	resp, err := cli.post("/networks/"+networkID+"/disconnect", nil, nd, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/types/types.go
+++ b/types/types.go
@@ -422,4 +422,5 @@ type NetworkConnect struct {
 // NetworkDisconnect represents the data to be used to disconnect a container from the network
 type NetworkDisconnect struct {
 	Container string
+	Force     bool
 }


### PR DESCRIPTION
There are cases as in https://github.com/docker/swarm/pull/1578 where swarm needs a way to
forcefully disconnect an endpoint from a network when a swarm node goes down ungracefully.

Signed-off-by: Madhu Venugopal <madhu@docker.com>