### PR TITLE
Change missing image detection for create

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -33,13 +33,13 @@ func (cli *Client) ContainerCreate(config *container.Config, hostConfig *contain
 
 	serverResp, err := cli.post("/containers/create", query, body, nil)
 	if err != nil {
-		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), config.Image) {
+		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 			return response, imageNotFoundError{config.Image}
 		}
 		return response, err
 	}
 
-	if serverResp.statusCode == 404 && strings.Contains(err.Error(), config.Image) {
+	if serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 		return response, imageNotFoundError{config.Image}
 	}
 


### PR DESCRIPTION
Daemon may not respond with the same image name
any more but it may be in a normalized form.
Generally checking for a image name doesn’t 
seem like a good idea because small image names
may match any possible error.

I'd be happy to only leave in `404` check if someone
is confident that this would not break somthing else.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>