### PR TITLE
Revert "Send graph storage options as part of the host configuration."

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -222,7 +222,6 @@ type HostConfig struct {
 	PublishAllPorts bool               // Should docker publish all exposed port for the container
 	ReadonlyRootfs  bool               // Is the container root filesystem in read-only
 	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
-	StorageOpt      []string           // Graph storage options per container
 	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode            // UTS namespace to use for the container
 	ShmSize         int64              // Total shm memory usage


### PR DESCRIPTION
This reverts commit 196e724016a2bf83f5c4196a78a6689579906f93.

Reverting this because the usecase is too specific for adding
--storage-opt on container creation. We can revisit this and other
solutions after Docker's 1.10 release.

Signed-off-by: Tibor Vass <tibor@docker.com>