### PR TITLE
Remove json tag in NetworkConnect.EndpointConfig

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -417,7 +417,7 @@ type NetworkCreateResponse struct {
 // NetworkConnect represents the data to be used to connect a container to the network
 type NetworkConnect struct {
 	Container      string
-	EndpointConfig *network.EndpointSettings `json:"endpoint_config"`
+	EndpointConfig *network.EndpointSettings `json:",omitempty"`
 }
 
 // NetworkDisconnect represents the data to be used to disconnect a container from the network


### PR DESCRIPTION
- Not necessary and docker follows camel case convention for json variables

Signed-off-by: Alessandro Boch <aboch@docker.com>