### PR TITLE
Make sure the TLS CA is properly loaded by default.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/docker/go-connections/tlsconfig"
 )
 
 // Client is the API client that performs all operations
@@ -41,15 +43,17 @@ type Client struct {
 func NewEnvClient() (*Client, error) {
 	var transport *http.Transport
 	if dockerCertPath := os.Getenv("DOCKER_CERT_PATH"); dockerCertPath != "" {
-		tlsc := &tls.Config{}
-
-		cert, err := tls.LoadX509KeyPair(filepath.Join(dockerCertPath, "cert.pem"), filepath.Join(dockerCertPath, "key.pem"))
+		options := tlsconfig.Options{
+			CAFile:             filepath.Join(dockerCertPath, "ca.pem"),
+			CertFile:           filepath.Join(dockerCertPath, "cert.pem"),
+			KeyFile:            filepath.Join(dockerCertPath, "key.pem"),
+			InsecureSkipVerify: os.Getenv("DOCKER_TLS_VERIFY") == "",
+		}
+		tlsc, err := tlsconfig.Client(options)
 		if err != nil {
-			return nil, fmt.Errorf("Error loading x509 key pair: %s", err)
+			return nil, err
 		}
 
-		tlsc.Certificates = append(tlsc.Certificates, cert)
-		tlsc.InsecureSkipVerify = os.Getenv("DOCKER_TLS_VERIFY") == ""
 		transport = &http.Transport{
 			TLSClientConfig: tlsc,
 		}


### PR DESCRIPTION
Fixes #40 

@lalyos do you mind double check that this change fixes the issue?

I ran your main script and I got containers without any problem:

```
calavera@d ~docker/engine-api (load_default_tls_ca)$ go run main.go
e6ba746640980a53768cfc3232d81b4cb3eec9853bc5b6452d7b011796e5eb0d
0c182e46e1f0dc251d7912d75594100e5aec73fc00bc5d4ae888df5f3e10294b
2ac87180b6d6462a349c1fa870b6382569530e3e09c3420c800dc57cdfcd3979
14faee23269d5610834970f0cdea0b5e44d71f5b42ff5124519fe15837925d6e
75c390da7fffab7707be55eebf3db15ef9b9ef2c9e11fa1795342e9099eb4f43
837d7c6f4cbec2742efefedb254dd66ad4d8de683dc61b3e0a6d89c40156735c
347e53037242db17be76aa06797130351c648b05f8f6052eafceebba1370aa47
c072a4abe6dea43ad54f828375baa149f92d976b7445a552e254af02c73f0029
73c8962f8278155d7a5edd752684226c657cc04f0cafcd2bdf09ed05530dc82b
```
Signed-off-by: David Calavera <david.calavera@gmail.com>