### PR TITLE
Add a DiskQuota field for container

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -180,6 +180,7 @@ type Resources struct {
 	CpusetCpus           string          // CpusetCpus 0-2, 0,1
 	CpusetMems           string          // CpusetMems 0-2, 0,1
 	Devices              []DeviceMapping // List of devices to map inside the container
+	DiskQuota            int64           // Disk limit (in bytes)
 	KernelMemory         int64           // Kernel memory limit (in bytes)
 	Memory               int64           // Memory limit (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)


### PR DESCRIPTION
See docker/docker#3804
I am adding disk quota support for btrfs, so adding this field is helpful.

Signed-off-by: Zhu Guihua <zhugh.fnst@cn.fujitsu.com>