### PR TITLE
types: remove Init{Sha1,Path}

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -222,8 +222,6 @@ type Info struct {
 	Architecture       string
 	IndexServerAddress string
 	RegistryConfig     *registry.ServiceConfig
-	InitSha1           string
-	InitPath           string
 	NCPU               int
 	MemTotal           int64
 	DockerRootDir      string


### PR DESCRIPTION
In preparation for removing dockerinit upstream, remove the docker info
fields that relate to dockerinit. This is related to docker/docker#19490.

Signed-off-by: Aleksa Sarai <asarai@suse.com>