### PR TITLE
Fix comment of swap limit

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -183,7 +183,7 @@ type Resources struct {
 	KernelMemory         int64           // Kernel memory limit (in bytes)
 	Memory               int64           // Memory limit (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)
-	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
+	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container


### PR DESCRIPTION
Set `-1` doesn't mean disable swap, disable swap means you
can't use swap memory, set `-1` really means you can use
unlimited swap memory.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>