### PR TITLE
Clean unused functions

### DIFF
--- a/types/container/hostconfig_unix.go
+++ b/types/container/hostconfig_unix.go
@@ -72,12 +72,6 @@ func (n NetworkMode) IsUserDefined() bool {
 	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer()
 }
 
-// IsPreDefinedNetwork indicates if a network is predefined by the daemon
-func IsPreDefinedNetwork(network string) bool {
-	n := NetworkMode(network)
-	return n.IsBridge() || n.IsHost() || n.IsNone()
-}
-
 //UserDefined indicates user-created network
 func (n NetworkMode) UserDefined() string {
 	if n.IsUserDefined() {

--- a/types/container/hostconfig_windows.go
+++ b/types/container/hostconfig_windows.go
@@ -49,11 +49,6 @@ func (n NetworkMode) NetworkName() string {
 	return ""
 }
 
-// IsPreDefinedNetwork indicates if a network is predefined by the daemon
-func IsPreDefinedNetwork(network string) bool {
-	return false
-}
-
 // ValidateNetMode ensures that the various combinations of requested
 // network settings are valid.
 func ValidateNetMode(c *Config, hc *HostConfig) error {


### PR DESCRIPTION
This is a duplicate function of `docker/runconfig/hostconfig_unix.go`, and we shouldn't call it from client side because it's related to platform. 

For example, if we have docker daemon running on Linux platform and client running on Windows platform, it's unmeaning for client to call `IsPreDefinedNetwork`.

Actually I think we can remove the whole file for same reason, and also some other functions. What do you think of this? @calavera 

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>