### PR TITLE
[Release 1.10] Verify auth errors for InternalServerError errors.

### DIFF
--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"io"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/engine-api/types"
@@ -20,7 +19,7 @@ func (cli *Client) ImagePull(options types.ImagePullOptions, privilegeFunc Reque
 	}
 
 	resp, err := cli.tryImageCreate(query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if isUnauthorized(resp, err) {
 		newAuthHeader, privilegeErr := privilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"io"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/engine-api/types"
@@ -17,7 +16,7 @@ func (cli *Client) ImagePush(options types.ImagePushOptions, privilegeFunc Reque
 	query.Set("tag", options.Tag)
 
 	resp, err := cli.tryImagePush(options.ImageID, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if isUnauthorized(resp, err) {
 		newAuthHeader, privilegeErr := privilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"net/http"
 	"net/url"
 
 	"github.com/docker/engine-api/types"
@@ -17,7 +16,7 @@ func (cli *Client) ImageSearch(options types.ImageSearchOptions, privilegeFunc R
 	query.Set("term", options.Term)
 
 	resp, err := cli.tryImageSearch(query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if isUnauthorized(resp, err) {
 		newAuthHeader, privilegeErr := privilegeFunc()
 		if privilegeErr != nil {
 			return results, privilegeErr

--- a/client/request.go
+++ b/client/request.go
@@ -174,3 +174,26 @@ func isTimeout(err error) bool {
 	t, ok := e.(timeout)
 	return ok && t.Timeout()
 }
+
+// isUnauthorized returns true if an operation fails with
+// and authorization error.
+// If the server returns a 500 error, we check the error message
+// response because the real error could have been streamed there.
+func isUnauthorized(resp *serverResponse, err error) bool {
+	switch resp.statusCode {
+	case http.StatusUnauthorized:
+		return true
+	case http.StatusInternalServerError:
+		if err == nil {
+			return false
+		}
+		loError := strings.ToLower(err.Error())
+		if strings.Contains(loError, "authentication is required") ||
+			strings.Contains(loError, "status 401") ||
+			strings.Contains(loError, "unauthorized") ||
+			strings.Contains(loError, "status code 401") {
+			return true
+		}
+	}
+	return false
+}

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestIsUnauthorized(t *testing.T) {
+	cases := []struct {
+		resp   *serverResponse
+		err    error
+		unauth bool
+	}{
+		{&serverResponse{statusCode: http.StatusOK}, nil, false},
+		{&serverResponse{statusCode: http.StatusUnauthorized}, nil, true},
+		{&serverResponse{statusCode: http.StatusInternalServerError}, nil, false},
+		{&serverResponse{statusCode: http.StatusInternalServerError}, fmt.Errorf("unauthorized"), true},
+	}
+
+	for _, cs := range cases {
+		got := isUnauthorized(cs.resp, cs.err)
+		if got != cs.unauth {
+			t.Fatalf("expected %v, got %v, with code %v and error %v", cs.unauth, got, cs.resp.statusCode, cs.err)
+		}
+	}
+}


### PR DESCRIPTION
Stream operations might hide authentication errors in the stream.
Verify that errored operations, like errored pulls, are not
authentication errors in reality.

Same patch as #58.

**CAUTION**: This change is on top of the `release/1.10` branch to merge into docker RC.

Signed-off-by: David Calavera <david.calavera@gmail.com>