### PR TITLE
client: fix conditional compilation for freebsd

### DIFF
--- a/client/client_darwin.go
+++ b/client/client_darwin.go
@@ -1,6 +1,0 @@
-// +build darwin
-
-package client
-
-// DefaultDockerHost defines os specific default if DOCKER_HOST is unset
-const DefaultDockerHost = "tcp://127.0.0.1:2375"

--- a/client/client_nounix.go
+++ b/client/client_nounix.go
@@ -1,6 +1,6 @@
-// +build linux
+// +build windows darwin
 
 package client
 
 // DefaultDockerHost defines os specific default if DOCKER_HOST is unset
-const DefaultDockerHost = "unix:///var/run/docker.sock"
+const DefaultDockerHost = "tcp://127.0.0.1:2375"

--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,6 +1,6 @@
-// +build windows
+// +build linux freebsd
 
 package client
 
 // DefaultDockerHost defines os specific default if DOCKER_HOST is unset
-const DefaultDockerHost = "tcp://127.0.0.1:2375"
+const DefaultDockerHost = "unix:///var/run/docker.sock"


### PR DESCRIPTION
The DockerDefaultHost was unset on freebsd. Fix this by adding a new
client_freebsd.go with the same default as the others.

Signed-off-by: Aleksa Sarai <asarai@suse.com>

/cc @calavera @runcom @vdemeester @crosbymichael