### PR TITLE
Remove duplicated code

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -39,18 +39,7 @@ func (cli *Client) ContainerCreate(config *container.Config, hostConfig *contain
 		return response, err
 	}
 
-	if serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
-		return response, imageNotFoundError{config.Image}
-	}
-
-	if err != nil {
-		return response, err
-	}
-	defer ensureReaderClosed(serverResp)
-
-	if err := json.NewDecoder(serverResp.body).Decode(&response); err != nil {
-		return response, err
-	}
-
-	return response, nil
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
 }


### PR DESCRIPTION
This removes duplicated code

Also removed a redundant check if err is nil, because we returned an "error" or "nil", so if err is actually nil, we're good to go as well.