### PR TITLE
Refactor JSON decoding, reduce defers

### DIFF
--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -27,11 +27,8 @@ func (cli *Client) ContainerCommit(options types.ContainerCommitOptions) (types.
 	if err != nil {
 		return response, err
 	}
-	defer ensureReaderClosed(resp)
 
-	if err := json.NewDecoder(resp.body).Decode(&response); err != nil {
-		return response, err
-	}
-
-	return response, nil
+	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
+	return response, err
 }

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -19,10 +19,10 @@ func (cli *Client) ContainerInspect(containerID string) (types.ContainerJSON, er
 		}
 		return types.ContainerJSON{}, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	var response types.ContainerJSON
 	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
 	return response, err
 }
 

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -46,9 +46,9 @@ func (cli *Client) ContainerList(options types.ContainerListOptions) ([]types.Co
 	if err != nil {
 		return nil, err
 	}
-	defer ensureReaderClosed(resp)
 
 	var containers []types.Container
 	err = json.NewDecoder(resp.body).Decode(&containers)
+	ensureReaderClosed(resp)
 	return containers, err
 }

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -20,8 +20,8 @@ func (cli *Client) ContainerTop(containerID string, arguments []string) (types.C
 	if err != nil {
 		return response, err
 	}
-	defer ensureReaderClosed(resp)
 
 	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/diff.go
+++ b/client/diff.go
@@ -15,11 +15,8 @@ func (cli *Client) ContainerDiff(containerID string) ([]types.ContainerChange, e
 	if err != nil {
 		return changes, err
 	}
-	defer ensureReaderClosed(serverResp)
 
-	if err := json.NewDecoder(serverResp.body).Decode(&changes); err != nil {
-		return changes, err
-	}
-
-	return changes, nil
+	err = json.NewDecoder(serverResp.body).Decode(&changes)
+	ensureReaderClosed(serverResp)
+	return changes, err
 }

--- a/client/exec.go
+++ b/client/exec.go
@@ -13,8 +13,8 @@ func (cli *Client) ContainerExecCreate(config types.ExecConfig) (types.Container
 	if err != nil {
 		return response, err
 	}
-	defer ensureReaderClosed(resp)
 	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
 	return response, err
 }
 
@@ -41,8 +41,8 @@ func (cli *Client) ContainerExecInspect(execID string) (types.ContainerExecInspe
 	if err != nil {
 		return response, err
 	}
-	defer ensureReaderClosed(resp)
 
 	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/history.go
+++ b/client/history.go
@@ -14,10 +14,8 @@ func (cli *Client) ImageHistory(imageID string) ([]types.ImageHistory, error) {
 	if err != nil {
 		return history, err
 	}
-	defer ensureReaderClosed(serverResp)
 
-	if err := json.NewDecoder(serverResp.body).Decode(&history); err != nil {
-		return history, err
-	}
-	return history, nil
+	err = json.NewDecoder(serverResp.body).Decode(&history)
+	ensureReaderClosed(serverResp)
+	return history, err
 }

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -32,8 +32,8 @@ func (cli *Client) ImageList(options types.ImageListOptions) ([]types.Image, err
 	if err != nil {
 		return images, err
 	}
-	defer ensureReaderClosed(serverResp)
 
 	err = json.NewDecoder(serverResp.body).Decode(&images)
+	ensureReaderClosed(serverResp)
 	return images, err
 }

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -22,9 +22,9 @@ func (cli *Client) ImageRemove(options types.ImageRemoveOptions) ([]types.ImageD
 	if err != nil {
 		return nil, err
 	}
-	defer ensureReaderClosed(resp)
 
 	var dels []types.ImageDelete
 	err = json.NewDecoder(resp.body).Decode(&dels)
+	ensureReaderClosed(resp)
 	return dels, err
 }

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -27,9 +27,9 @@ func (cli *Client) ImageSearch(options types.ImageSearchOptions, privilegeFunc R
 	if err != nil {
 		return results, err
 	}
-	defer ensureReaderClosed(resp)
 
 	err = json.NewDecoder(resp.body).Decode(&results)
+	ensureReaderClosed(resp)
 	return results, err
 }
 

--- a/client/login.go
+++ b/client/login.go
@@ -19,9 +19,9 @@ func (cli *Client) RegistryLogin(auth types.AuthConfig) (types.AuthResponse, err
 	if err != nil {
 		return types.AuthResponse{}, err
 	}
-	defer ensureReaderClosed(resp)
 
 	var response types.AuthResponse
 	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/network.go
+++ b/client/network.go
@@ -65,8 +65,8 @@ func (cli *Client) NetworkList(options types.NetworkListOptions) ([]types.Networ
 	if err != nil {
 		return networkResources, err
 	}
-	defer ensureReaderClosed(resp)
 	err = json.NewDecoder(resp.body).Decode(&networkResources)
+	ensureReaderClosed(resp)
 	return networkResources, err
 }
 
@@ -80,7 +80,7 @@ func (cli *Client) NetworkInspect(networkID string) (types.NetworkResource, erro
 		}
 		return networkResource, err
 	}
-	defer ensureReaderClosed(resp)
 	err = json.NewDecoder(resp.body).Decode(&networkResource)
+	ensureReaderClosed(resp)
 	return networkResource, err
 }

--- a/client/version.go
+++ b/client/version.go
@@ -12,9 +12,9 @@ func (cli *Client) ServerVersion() (types.Version, error) {
 	if err != nil {
 		return types.Version{}, err
 	}
-	defer ensureReaderClosed(resp)
 
 	var server types.Version
 	err = json.NewDecoder(resp.body).Decode(&server)
+	ensureReaderClosed(resp)
 	return server, err
 }

--- a/client/volume.go
+++ b/client/volume.go
@@ -25,9 +25,9 @@ func (cli *Client) VolumeList(filter filters.Args) (types.VolumesListResponse, e
 	if err != nil {
 		return volumes, err
 	}
-	defer ensureReaderClosed(resp)
 
 	err = json.NewDecoder(resp.body).Decode(&volumes)
+	ensureReaderClosed(resp)
 	return volumes, err
 }
 
@@ -41,8 +41,8 @@ func (cli *Client) VolumeInspect(volumeID string) (types.Volume, error) {
 		}
 		return volume, err
 	}
-	defer ensureReaderClosed(resp)
 	err = json.NewDecoder(resp.body).Decode(&volume)
+	ensureReaderClosed(resp)
 	return volume, err
 }
 
@@ -53,8 +53,8 @@ func (cli *Client) VolumeCreate(options types.VolumeCreateRequest) (types.Volume
 	if err != nil {
 		return volume, err
 	}
-	defer ensureReaderClosed(resp)
 	err = json.NewDecoder(resp.body).Decode(&volume)
+	ensureReaderClosed(resp)
 	return volume, err
 }
 


### PR DESCRIPTION
There's no need to check for error-nilness if we're going to return a "nil" on success.

Also, removed defer statements because they were no longer needed, and have some overhead; http://lk4d4.darth.io/posts/defer/
