### PR TITLE
Windows: add support for named pipe transport

### DIFF
--- a/client/hijack.go
+++ b/client/hijack.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/engine-api/client/transport"
 	"github.com/docker/engine-api/types"
 )
 
@@ -156,9 +157,12 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 }
 
 func dial(proto, addr string, tlsConfig *tls.Config) (net.Conn, error) {
-	if tlsConfig != nil && proto != "unix" {
+	if tlsConfig != nil && proto != "unix" && proto != "npipe" {
 		// Notice this isn't Go standard's tls.Dial function
 		return tlsDial(proto, addr, tlsConfig)
+	}
+	if proto == "npipe" {
+		return transport.DialPipe(addr, 32*time.Second)
 	}
 	return net.Dial(proto, addr)
 }

--- a/client/transport/npipe_nowindows.go
+++ b/client/transport/npipe_nowindows.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package transport
+
+import (
+	"net"
+	"syscall"
+	"time"
+)
+
+// DialPipe connects to a Windows named pipe. This is not supported on other OSes.
+func DialPipe(_ string, _ time.Duration) (net.Conn, error) {
+	return nil, syscall.EAFNOSUPPORT
+}

--- a/client/transport/npipe_windows.go
+++ b/client/transport/npipe_windows.go
@@ -1,0 +1,13 @@
+package transport
+
+import (
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// DialPipe connects to a Windows named pipe.
+func DialPipe(addr string, timeout time.Duration) (net.Conn, error) {
+	return winio.DialPipe(addr, &timeout)
+}

--- a/client/transport/transport.go
+++ b/client/transport/transport.go
@@ -52,6 +52,10 @@ func defaultTransport(proto, addr string) *http.Transport {
 		tr.Dial = func(_, _ string) (net.Conn, error) {
 			return net.DialTimeout(proto, addr, timeout)
 		}
+	} else if proto == "npipe" {
+		tr.Dial = func(_, _ string) (net.Conn, error) {
+			return DialPipe(addr, timeout)
+		}
 	} else {
 		tr.Proxy = http.ProxyFromEnvironment
 		tr.Dial = (&net.Dialer{Timeout: timeout}).Dial


### PR DESCRIPTION
This allows Windows to use named pipes in the way that Linux uses unix domain sockets.

This does not yet change the default to use named pipes.

See docker/docker#19911 for the server-side changes.