### PR TITLE
Add experimental interface for Checkpoint/Restore.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ deps:
 test:
 	go test -tags=test ./...
 
+test_experimental:
+	go test -tags="test experimental" ./...
+
 validate:
 	go vet ./...
 	test -z "$(golint ./... | tee /dev/stderr)"

--- a/client/container_checkpoint.go
+++ b/client/container_checkpoint.go
@@ -1,0 +1,15 @@
+// +build experimental
+
+package client
+
+import (
+	"github.com/docker/engine-api/types"
+)
+
+// ContainerCheckpoint checkpoints a running container
+func (cli *Client) ContainerCheckpoint(containerID string, options types.CriuConfig) error {
+	resp, err := cli.post("/containers/"+containerID+"/checkpoint", nil, options, nil)
+	ensureReaderClosed(resp)
+
+	return err
+}

--- a/client/container_restore.go
+++ b/client/container_restore.go
@@ -1,0 +1,22 @@
+// +build experimental
+
+package client
+
+import (
+	"net/url"
+	"github.com/docker/engine-api/types"
+)
+
+// ContainerRestore restores a running container
+func (cli *Client) ContainerRestore(containerID string, options types.CriuConfig, forceRestore bool) error {
+	query := url.Values{}
+
+	if forceRestore {
+		query.Set("force", "1")
+	}
+
+	resp, err := cli.post("/containers/"+containerID+"/restore", query, options, nil)
+	ensureReaderClosed(resp)
+
+	return err
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -14,6 +14,7 @@ import (
 
 // APIClient is an interface that clients that talk with a docker server must implement.
 type APIClient interface {
+	ExperimentalAPIClient
 	ClientVersion() string
 	ContainerAttach(options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)

--- a/client/interface_experimental.go
+++ b/client/interface_experimental.go
@@ -1,0 +1,13 @@
+// +build experimental
+
+package client
+
+import (
+	"github.com/docker/engine-api/types"
+)
+
+// ExperimentalAPIClient is an interface that implements Experimental API methods
+type ExperimentalAPIClient interface {
+	ContainerCheckpoint(containerID string, options types.CriuConfig) error
+	ContainerRestore(containerID string, options types.CriuConfig, forceRestore bool) error
+}

--- a/client/interface_stub.go
+++ b/client/interface_stub.go
@@ -1,0 +1,7 @@
+// +build !experimental
+
+package client
+
+// ExperimentalAPIClient is an interface that stubs out experimental methods in normal builds
+type ExperimentalAPIClient interface {
+}

--- a/types/configs.go
+++ b/types/configs.go
@@ -38,6 +38,13 @@ type ContainerCommitConfig struct {
 	Config       *container.Config
 }
 
+// CriuConfig holds configuration options passed down to libcontainer and CRIU
+type CriuConfig struct {
+	ImagesDirectory string
+	WorkDirectory   string
+	LeaveRunning    bool
+}
+
 // ExecConfig is a small subset of the Config struct that hold the configuration
 // for the exec feature of docker.
 type ExecConfig struct {

--- a/types/types.go
+++ b/types/types.go
@@ -258,9 +258,9 @@ type ExecStartCheck struct {
 	Tty bool
 }
 
-// ContainerState stores container's running state
+// ContainerStateBase stores container's running state
 // it's part of ContainerJSONBase and will return by "inspect" command
-type ContainerState struct {
+type ContainerStateBase struct {
 	Status     string
 	Running    bool
 	Paused     bool

--- a/types/types_experimental.go
+++ b/types/types_experimental.go
@@ -1,0 +1,10 @@
+// +build experimental
+
+package types
+
+// ContainerState stores container's running state
+type ContainerState struct {
+	ContainerStateBase
+	Checkpointed   bool
+	CheckpointedAt string
+}

--- a/types/types_stub.go
+++ b/types/types_stub.go
@@ -1,0 +1,8 @@
+// +build !experimental
+
+package types
+
+// ContainerState stores container's running state
+type ContainerState struct {
+	ContainerStateBase
+}


### PR DESCRIPTION
The interface is a prerequisite for C/R support in the docker engine.

Signed-off-by: Ross Boucher <rboucher@gmail.com>