### PR TITLE
Set DefaultDockerHost on Solaris

### DIFF
--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd
+// +build linux freebsd solaris
 
 package client
 


### PR DESCRIPTION
This PR is to get client_unix.go in engine-api/client/client_unix.go to build for Solaris as well so that DefaultDockerHost is set on Solaris as well.
This is part of a larger effort for a native port of Docker on Solairs.

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>