### PR TITLE
Fix implicit conversion of transport sender in canceler_14.

### DIFF
--- a/client/transport/cancellable/canceler_go14.go
+++ b/client/transport/cancellable/canceler_go14.go
@@ -16,7 +16,7 @@ type requestCanceler interface {
 	CancelRequest(*http.Request)
 }
 
-func canceler(client transport.Client, req *http.Request) func() {
+func canceler(client transport.Sender, req *http.Request) func() {
 	rc, ok := client.(requestCanceler)
 	if !ok {
 		return func() {}

--- a/client/transport/cancellable/cancellable.go
+++ b/client/transport/cancellable/cancellable.go
@@ -36,7 +36,7 @@ func Do(ctx context.Context, client transport.Sender, req *http.Request) (*http.
 		client = http.DefaultClient
 	}
 
-	// Request cancelation changed in Go 1.5, see cancelreq.go and cancelreq_go14.go.
+	// Request cancelation changed in Go 1.5, see canceler.go and canceler_go14.go.
 	cancel := canceler(client, req)
 
 	type responseAndError struct {


### PR DESCRIPTION
Fix docker build with gccgo:

```
00:22:12 # github.com/docker/engine-api/client/transport/cancellable
00:22:12 vendor/src/github.com/docker/engine-api/client/transport/cancellable/cancellable.go:40:21: error: argument 1 has incompatible type (need explicit conversion; missing method 'Scheme')
00:22:12   cancel := canceler(client, req)
```

Signed-off-by: David Calavera <david.calavera@gmail.com>