### PR TITLE
Add JSON schema for API types that return JSON.

### DIFF
--- a/schema/generator/schema-generator.go
+++ b/schema/generator/schema-generator.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/calavera/go-jsonschema-generator"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/events"
+	"github.com/docker/engine-api/types/registry"
+)
+
+const (
+	defaultDest = "schema/json"
+	defaultTag  = "master"
+)
+
+var sources = map[string]interface{}{
+	"ps":              []types.Container{},                 // docker ps
+	"inspect":         types.ContainerJSON{},               // docker inspect
+	"stats":           []types.Stats{},                     // docker stats
+	"events":          []events.Message{},                  // docker events
+	"commit":          types.ContainerCommitResponse{},     // docker commit
+	"wait":            types.ContainerWaitResponse{},       // docker wait
+	"create":          types.ContainerCreateResponse{},     // docker create
+	"top":             types.ContainerProcessList{},        // docker top
+	"cp-stat":         types.ContainerPathStat{},           // docker cp stat
+	"diff":            []types.ContainerChange{},           // docker diff
+	"exec-create":     types.ContainerExecCreateResponse{}, // docker exec create
+	"exec-inspect":    types.ContainerExecInspect{},        // docker exec inspect
+	"history":         []types.ImageHistory{},              // docker history
+	"image-inspect":   types.ImageInspect{},                // docker inspect --image
+	"images":          []types.Image{},                     // docker images
+	"image-delete":    []types.ImageDelete{},               // docker rmi
+	"search":          []registry.SearchResult{},           // docker search
+	"info":            types.Info{},                        // docker info
+	"login":           types.AuthResponse{},                // docker login
+	"network-create":  types.NetworkCreateResponse{},       // docker network create
+	"network-ls":      []types.NetworkResource{},           // docker network ls
+	"network-inspect": types.NetworkResource{},             // docker network inspect
+	"volume-ls":       types.VolumesListResponse{},         // docker volume ls
+	"volume":          types.Volume{},                      // docker volume inspect / docker volume create
+}
+
+func main() {
+	tag := flag.String("tag", defaultTag, "version tag for the schemas, `master` by default")
+	flag.Parse()
+
+	args := flag.Args()
+
+	if len(args) > 2 {
+		fmt.Printf("Usage: %s [--tag TAG] [DESTINATION-PATH]\n", args[0])
+		os.Exit(1)
+	}
+
+	dest := defaultDest
+	if len(args) == 2 {
+		dest = args[1]
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	dest, err = filepath.Abs(filepath.Join(cwd, dest))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Generating json schemas in: %s\n", dest)
+
+	tagDest := filepath.Join(dest, *tag)
+	if err := os.MkdirAll(tagDest, 0755); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	for f, t := range sources {
+		s := &jsonschema.Document{}
+		s.Read(t)
+
+		m, err := s.Marshal()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("- writing %s\n", f)
+		err = ioutil.WriteFile(filepath.Join(tagDest, f+".json"), m, 0644)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+}

--- a/schema/json/master/commit.json
+++ b/schema/json/master/commit.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Id": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Id"
+    ]
+}

--- a/schema/json/master/cp-stat.json
+++ b/schema/json/master/cp-stat.json
@@ -1,0 +1,130 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "linkTarget": {
+            "type": "string"
+        },
+        "mode": {
+            "type": "integer"
+        },
+        "mtime": {
+            "type": "object",
+            "properties": {
+                "loc": {
+                    "type": "object",
+                    "properties": {
+                        "cacheEnd": {
+                            "type": "integer"
+                        },
+                        "cacheStart": {
+                            "type": "integer"
+                        },
+                        "cacheZone": {
+                            "type": "object",
+                            "properties": {
+                                "isDST": {
+                                    "type": "bool"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "offset": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "offset",
+                                "isDST"
+                            ]
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "tx": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "index": {
+                                        "type": "integer"
+                                    },
+                                    "isstd": {
+                                        "type": "bool"
+                                    },
+                                    "isutc": {
+                                        "type": "bool"
+                                    },
+                                    "when": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "when",
+                                    "index",
+                                    "isstd",
+                                    "isutc"
+                                ]
+                            }
+                        },
+                        "zone": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "isDST": {
+                                        "type": "bool"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "offset": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "offset",
+                                    "isDST"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "zone",
+                        "tx",
+                        "cacheStart",
+                        "cacheEnd",
+                        "cacheZone"
+                    ]
+                },
+                "nsec": {
+                    "type": "integer"
+                },
+                "sec": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "sec",
+                "nsec",
+                "loc"
+            ]
+        },
+        "name": {
+            "type": "string"
+        },
+        "size": {
+            "type": "integer"
+        }
+    },
+    "required": [
+        "name",
+        "size",
+        "mode",
+        "mtime",
+        "linkTarget"
+    ]
+}

--- a/schema/json/master/create.json
+++ b/schema/json/master/create.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Id": {
+            "type": "string"
+        },
+        "Warnings": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "Id",
+        "Warnings"
+    ]
+}

--- a/schema/json/master/diff.json
+++ b/schema/json/master/diff.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Kind": {
+                "type": "integer"
+            },
+            "Path": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "Kind",
+            "Path"
+        ]
+    }
+}

--- a/schema/json/master/events.json
+++ b/schema/json/master/events.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Action": {
+                "type": "string"
+            },
+            "Actor": {
+                "type": "object",
+                "properties": {
+                    "Attributes": {
+                        "type": "object",
+                        "properties": {
+                            ".*": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "ID": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "ID",
+                    "Attributes"
+                ]
+            },
+            "Type": {
+                "type": "string"
+            },
+            "from": {
+                "type": "string"
+            },
+            "id": {
+                "type": "string"
+            },
+            "status": {
+                "type": "string"
+            },
+            "time": {
+                "type": "integer"
+            },
+            "timeNano": {
+                "type": "integer"
+            }
+        },
+        "required": [
+            "Type",
+            "Action",
+            "Actor"
+        ]
+    }
+}

--- a/schema/json/master/exec-create.json
+++ b/schema/json/master/exec-create.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Id": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Id"
+    ]
+}

--- a/schema/json/master/exec-inspect.json
+++ b/schema/json/master/exec-inspect.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "ContainerID": {
+            "type": "string"
+        },
+        "ExecID": {
+            "type": "string"
+        },
+        "ExitCode": {
+            "type": "integer"
+        },
+        "Running": {
+            "type": "bool"
+        }
+    },
+    "required": [
+        "ExecID",
+        "ContainerID",
+        "Running",
+        "ExitCode"
+    ]
+}

--- a/schema/json/master/history.json
+++ b/schema/json/master/history.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Comment": {
+                "type": "string"
+            },
+            "Created": {
+                "type": "integer"
+            },
+            "CreatedBy": {
+                "type": "string"
+            },
+            "Id": {
+                "type": "string"
+            },
+            "Size": {
+                "type": "integer"
+            },
+            "Tags": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "required": [
+            "Id",
+            "Created",
+            "CreatedBy",
+            "Tags",
+            "Size",
+            "Comment"
+        ]
+    }
+}

--- a/schema/json/master/image-delete.json
+++ b/schema/json/master/image-delete.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Deleted": {
+                "type": "string"
+            },
+            "Untagged": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/schema/json/master/image-inspect.json
+++ b/schema/json/master/image-inspect.json
@@ -1,0 +1,361 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Architecture": {
+            "type": "string"
+        },
+        "Author": {
+            "type": "string"
+        },
+        "Comment": {
+            "type": "string"
+        },
+        "Config": {
+            "type": "object",
+            "properties": {
+                "ArgsEscaped": {
+                    "type": "bool"
+                },
+                "AttachStderr": {
+                    "type": "bool"
+                },
+                "AttachStdin": {
+                    "type": "bool"
+                },
+                "AttachStdout": {
+                    "type": "bool"
+                },
+                "Cmd": {
+                    "type": "object",
+                    "properties": {
+                        "parts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "parts"
+                    ]
+                },
+                "Domainname": {
+                    "type": "string"
+                },
+                "Entrypoint": {
+                    "type": "object",
+                    "properties": {
+                        "parts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "parts"
+                    ]
+                },
+                "Env": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ExposedPorts": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "Hostname": {
+                    "type": "string"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "Labels": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "MacAddress": {
+                    "type": "string"
+                },
+                "NetworkDisabled": {
+                    "type": "bool"
+                },
+                "OnBuild": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "OpenStdin": {
+                    "type": "bool"
+                },
+                "PublishService": {
+                    "type": "string"
+                },
+                "StdinOnce": {
+                    "type": "bool"
+                },
+                "StopSignal": {
+                    "type": "string"
+                },
+                "Tty": {
+                    "type": "bool"
+                },
+                "User": {
+                    "type": "string"
+                },
+                "Volumes": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "WorkingDir": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Hostname",
+                "Domainname",
+                "User",
+                "AttachStdin",
+                "AttachStdout",
+                "AttachStderr",
+                "Tty",
+                "OpenStdin",
+                "StdinOnce",
+                "Env",
+                "Cmd",
+                "Image",
+                "Volumes",
+                "WorkingDir",
+                "Entrypoint",
+                "OnBuild",
+                "Labels"
+            ]
+        },
+        "Container": {
+            "type": "string"
+        },
+        "ContainerConfig": {
+            "type": "object",
+            "properties": {
+                "ArgsEscaped": {
+                    "type": "bool"
+                },
+                "AttachStderr": {
+                    "type": "bool"
+                },
+                "AttachStdin": {
+                    "type": "bool"
+                },
+                "AttachStdout": {
+                    "type": "bool"
+                },
+                "Cmd": {
+                    "type": "object",
+                    "properties": {
+                        "parts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "parts"
+                    ]
+                },
+                "Domainname": {
+                    "type": "string"
+                },
+                "Entrypoint": {
+                    "type": "object",
+                    "properties": {
+                        "parts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "parts"
+                    ]
+                },
+                "Env": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ExposedPorts": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "Hostname": {
+                    "type": "string"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "Labels": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "MacAddress": {
+                    "type": "string"
+                },
+                "NetworkDisabled": {
+                    "type": "bool"
+                },
+                "OnBuild": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "OpenStdin": {
+                    "type": "bool"
+                },
+                "PublishService": {
+                    "type": "string"
+                },
+                "StdinOnce": {
+                    "type": "bool"
+                },
+                "StopSignal": {
+                    "type": "string"
+                },
+                "Tty": {
+                    "type": "bool"
+                },
+                "User": {
+                    "type": "string"
+                },
+                "Volumes": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "WorkingDir": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Hostname",
+                "Domainname",
+                "User",
+                "AttachStdin",
+                "AttachStdout",
+                "AttachStderr",
+                "Tty",
+                "OpenStdin",
+                "StdinOnce",
+                "Env",
+                "Cmd",
+                "Image",
+                "Volumes",
+                "WorkingDir",
+                "Entrypoint",
+                "OnBuild",
+                "Labels"
+            ]
+        },
+        "Created": {
+            "type": "string"
+        },
+        "DockerVersion": {
+            "type": "string"
+        },
+        "GraphDriver": {
+            "type": "object",
+            "properties": {
+                "Data": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "Name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Data"
+            ]
+        },
+        "Id": {
+            "type": "string"
+        },
+        "Os": {
+            "type": "string"
+        },
+        "Parent": {
+            "type": "string"
+        },
+        "RepoDigests": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "RepoTags": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "Size": {
+            "type": "integer"
+        },
+        "VirtualSize": {
+            "type": "integer"
+        }
+    },
+    "required": [
+        "Id",
+        "RepoTags",
+        "RepoDigests",
+        "Parent",
+        "Comment",
+        "Created",
+        "Container",
+        "ContainerConfig",
+        "DockerVersion",
+        "Author",
+        "Config",
+        "Architecture",
+        "Os",
+        "Size",
+        "VirtualSize",
+        "GraphDriver"
+    ]
+}

--- a/schema/json/master/images.json
+++ b/schema/json/master/images.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Created": {
+                "type": "integer"
+            },
+            "Id": {
+                "type": "string"
+            },
+            "Labels": {
+                "type": "object",
+                "properties": {
+                    ".*": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ParentId": {
+                "type": "string"
+            },
+            "RepoDigests": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "RepoTags": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "Size": {
+                "type": "integer"
+            },
+            "VirtualSize": {
+                "type": "integer"
+            }
+        },
+        "required": [
+            "Id",
+            "ParentId",
+            "RepoTags",
+            "RepoDigests",
+            "Created",
+            "Size",
+            "VirtualSize",
+            "Labels"
+        ]
+    }
+}

--- a/schema/json/master/info.json
+++ b/schema/json/master/info.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Architecture": {
+            "type": "string"
+        },
+        "BridgeNfIp6tables": {
+            "type": "bool"
+        },
+        "BridgeNfIptables": {
+            "type": "bool"
+        },
+        "CPUSet": {
+            "type": "bool"
+        },
+        "CPUShares": {
+            "type": "bool"
+        },
+        "ClusterAdvertise": {
+            "type": "string"
+        },
+        "ClusterStore": {
+            "type": "string"
+        },
+        "Containers": {
+            "type": "integer"
+        },
+        "ContainersPaused": {
+            "type": "integer"
+        },
+        "ContainersRunning": {
+            "type": "integer"
+        },
+        "ContainersStopped": {
+            "type": "integer"
+        },
+        "CpuCfsPeriod": {
+            "type": "bool"
+        },
+        "CpuCfsQuota": {
+            "type": "bool"
+        },
+        "Debug": {
+            "type": "bool"
+        },
+        "DockerRootDir": {
+            "type": "string"
+        },
+        "Driver": {
+            "type": "string"
+        },
+        "DriverStatus": {
+            "type": "array"
+        },
+        "ExecutionDriver": {
+            "type": "string"
+        },
+        "ExperimentalBuild": {
+            "type": "bool"
+        },
+        "HttpProxy": {
+            "type": "string"
+        },
+        "HttpsProxy": {
+            "type": "string"
+        },
+        "ID": {
+            "type": "string"
+        },
+        "IPv4Forwarding": {
+            "type": "bool"
+        },
+        "Images": {
+            "type": "integer"
+        },
+        "IndexServerAddress": {
+            "type": "string"
+        },
+        "KernelVersion": {
+            "type": "string"
+        },
+        "Labels": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "LoggingDriver": {
+            "type": "string"
+        },
+        "MemTotal": {
+            "type": "integer"
+        },
+        "MemoryLimit": {
+            "type": "bool"
+        },
+        "NCPU": {
+            "type": "integer"
+        },
+        "NEventsListener": {
+            "type": "integer"
+        },
+        "NFd": {
+            "type": "integer"
+        },
+        "NGoroutines": {
+            "type": "integer"
+        },
+        "Name": {
+            "type": "string"
+        },
+        "NoProxy": {
+            "type": "string"
+        },
+        "OSType": {
+            "type": "string"
+        },
+        "OomKillDisable": {
+            "type": "bool"
+        },
+        "OperatingSystem": {
+            "type": "string"
+        },
+        "Plugins": {
+            "type": "object",
+            "properties": {
+                "Authorization": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "Network": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "Volume": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "Volume",
+                "Network",
+                "Authorization"
+            ]
+        },
+        "RegistryConfig": {
+            "type": "object",
+            "properties": {
+                "IndexConfigs": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "InsecureRegistryCIDRs": {
+                    "type": "array"
+                },
+                "Mirrors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "InsecureRegistryCIDRs",
+                "IndexConfigs",
+                "Mirrors"
+            ]
+        },
+        "ServerVersion": {
+            "type": "string"
+        },
+        "SwapLimit": {
+            "type": "bool"
+        },
+        "SystemStatus": {
+            "type": "array"
+        },
+        "SystemTime": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "ID",
+        "Containers",
+        "ContainersRunning",
+        "ContainersPaused",
+        "ContainersStopped",
+        "Images",
+        "Driver",
+        "DriverStatus",
+        "SystemStatus",
+        "Plugins",
+        "MemoryLimit",
+        "SwapLimit",
+        "CpuCfsPeriod",
+        "CpuCfsQuota",
+        "CPUShares",
+        "CPUSet",
+        "IPv4Forwarding",
+        "BridgeNfIptables",
+        "BridgeNfIp6tables",
+        "Debug",
+        "NFd",
+        "OomKillDisable",
+        "NGoroutines",
+        "SystemTime",
+        "ExecutionDriver",
+        "LoggingDriver",
+        "NEventsListener",
+        "KernelVersion",
+        "OperatingSystem",
+        "OSType",
+        "Architecture",
+        "IndexServerAddress",
+        "RegistryConfig",
+        "NCPU",
+        "MemTotal",
+        "DockerRootDir",
+        "HttpProxy",
+        "HttpsProxy",
+        "NoProxy",
+        "Name",
+        "Labels",
+        "ExperimentalBuild",
+        "ServerVersion",
+        "ClusterStore",
+        "ClusterAdvertise"
+    ]
+}

--- a/schema/json/master/inspect.json
+++ b/schema/json/master/inspect.json
@@ -1,0 +1,787 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Config": {
+            "type": "object",
+            "properties": {
+                "ArgsEscaped": {
+                    "type": "bool"
+                },
+                "AttachStderr": {
+                    "type": "bool"
+                },
+                "AttachStdin": {
+                    "type": "bool"
+                },
+                "AttachStdout": {
+                    "type": "bool"
+                },
+                "Cmd": {
+                    "type": "object",
+                    "properties": {
+                        "parts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "parts"
+                    ]
+                },
+                "Domainname": {
+                    "type": "string"
+                },
+                "Entrypoint": {
+                    "type": "object",
+                    "properties": {
+                        "parts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "parts"
+                    ]
+                },
+                "Env": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ExposedPorts": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "Hostname": {
+                    "type": "string"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "Labels": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "MacAddress": {
+                    "type": "string"
+                },
+                "NetworkDisabled": {
+                    "type": "bool"
+                },
+                "OnBuild": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "OpenStdin": {
+                    "type": "bool"
+                },
+                "PublishService": {
+                    "type": "string"
+                },
+                "StdinOnce": {
+                    "type": "bool"
+                },
+                "StopSignal": {
+                    "type": "string"
+                },
+                "Tty": {
+                    "type": "bool"
+                },
+                "User": {
+                    "type": "string"
+                },
+                "Volumes": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "WorkingDir": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Hostname",
+                "Domainname",
+                "User",
+                "AttachStdin",
+                "AttachStdout",
+                "AttachStderr",
+                "Tty",
+                "OpenStdin",
+                "StdinOnce",
+                "Env",
+                "Cmd",
+                "Image",
+                "Volumes",
+                "WorkingDir",
+                "Entrypoint",
+                "OnBuild",
+                "Labels"
+            ]
+        },
+        "ContainerJSONBase": {
+            "type": "object",
+            "properties": {
+                "AppArmorProfile": {
+                    "type": "string"
+                },
+                "Args": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "Created": {
+                    "type": "string"
+                },
+                "Driver": {
+                    "type": "string"
+                },
+                "ExecIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "GraphDriver": {
+                    "type": "object",
+                    "properties": {
+                        "Data": {
+                            "type": "object",
+                            "properties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Name",
+                        "Data"
+                    ]
+                },
+                "HostConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Binds": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "CapAdd": {
+                            "type": "object",
+                            "properties": {
+                                "parts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "parts"
+                            ]
+                        },
+                        "CapDrop": {
+                            "type": "object",
+                            "properties": {
+                                "parts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "parts"
+                            ]
+                        },
+                        "ConsoleSize": {},
+                        "ContainerIDFile": {
+                            "type": "string"
+                        },
+                        "Dns": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "DnsOptions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "DnsSearch": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ExtraHosts": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "GroupAdd": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "IpcMode": {
+                            "type": "string"
+                        },
+                        "Isolation": {
+                            "type": "string"
+                        },
+                        "Links": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "LogConfig": {
+                            "type": "object",
+                            "properties": {
+                                "Config": {
+                                    "type": "object",
+                                    "properties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "Type": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "Type",
+                                "Config"
+                            ]
+                        },
+                        "NetworkMode": {
+                            "type": "string"
+                        },
+                        "OomScoreAdj": {
+                            "type": "integer"
+                        },
+                        "PidMode": {
+                            "type": "string"
+                        },
+                        "PortBindings": {
+                            "type": "object",
+                            "properties": {
+                                ".*": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "Privileged": {
+                            "type": "bool"
+                        },
+                        "PublishAllPorts": {
+                            "type": "bool"
+                        },
+                        "ReadonlyRootfs": {
+                            "type": "bool"
+                        },
+                        "Resources": {
+                            "type": "object",
+                            "properties": {
+                                "BlkioDeviceReadBps": {
+                                    "type": "array"
+                                },
+                                "BlkioDeviceReadIOps": {
+                                    "type": "array"
+                                },
+                                "BlkioDeviceWriteBps": {
+                                    "type": "array"
+                                },
+                                "BlkioDeviceWriteIOps": {
+                                    "type": "array"
+                                },
+                                "BlkioWeight": {
+                                    "type": "integer"
+                                },
+                                "BlkioWeightDevice": {
+                                    "type": "array"
+                                },
+                                "CgroupParent": {
+                                    "type": "string"
+                                },
+                                "CpuPeriod": {
+                                    "type": "integer"
+                                },
+                                "CpuQuota": {
+                                    "type": "integer"
+                                },
+                                "CpuShares": {
+                                    "type": "integer"
+                                },
+                                "CpusetCpus": {
+                                    "type": "string"
+                                },
+                                "CpusetMems": {
+                                    "type": "string"
+                                },
+                                "Devices": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "CgroupPermissions": {
+                                                "type": "string"
+                                            },
+                                            "PathInContainer": {
+                                                "type": "string"
+                                            },
+                                            "PathOnHost": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "PathOnHost",
+                                            "PathInContainer",
+                                            "CgroupPermissions"
+                                        ]
+                                    }
+                                },
+                                "KernelMemory": {
+                                    "type": "integer"
+                                },
+                                "Memory": {
+                                    "type": "integer"
+                                },
+                                "MemoryReservation": {
+                                    "type": "integer"
+                                },
+                                "MemorySwap": {
+                                    "type": "integer"
+                                },
+                                "MemorySwappiness": {
+                                    "type": "integer"
+                                },
+                                "OomKillDisable": {
+                                    "type": "bool"
+                                },
+                                "PidsLimit": {
+                                    "type": "integer"
+                                },
+                                "Ulimits": {
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "CpuShares",
+                                "CgroupParent",
+                                "BlkioWeight",
+                                "BlkioWeightDevice",
+                                "BlkioDeviceReadBps",
+                                "BlkioDeviceWriteBps",
+                                "BlkioDeviceReadIOps",
+                                "BlkioDeviceWriteIOps",
+                                "CpuPeriod",
+                                "CpuQuota",
+                                "CpusetCpus",
+                                "CpusetMems",
+                                "Devices",
+                                "KernelMemory",
+                                "Memory",
+                                "MemoryReservation",
+                                "MemorySwap",
+                                "MemorySwappiness",
+                                "OomKillDisable",
+                                "PidsLimit",
+                                "Ulimits"
+                            ]
+                        },
+                        "RestartPolicy": {
+                            "type": "object",
+                            "properties": {
+                                "MaximumRetryCount": {
+                                    "type": "integer"
+                                },
+                                "Name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "Name",
+                                "MaximumRetryCount"
+                            ]
+                        },
+                        "SecurityOpt": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ShmSize": {
+                            "type": "integer"
+                        },
+                        "Tmpfs": {
+                            "type": "object",
+                            "properties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "UTSMode": {
+                            "type": "string"
+                        },
+                        "VolumeDriver": {
+                            "type": "string"
+                        },
+                        "VolumesFrom": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "Binds",
+                        "ContainerIDFile",
+                        "LogConfig",
+                        "NetworkMode",
+                        "PortBindings",
+                        "RestartPolicy",
+                        "VolumeDriver",
+                        "VolumesFrom",
+                        "CapAdd",
+                        "CapDrop",
+                        "Dns",
+                        "DnsOptions",
+                        "DnsSearch",
+                        "ExtraHosts",
+                        "GroupAdd",
+                        "IpcMode",
+                        "Links",
+                        "OomScoreAdj",
+                        "PidMode",
+                        "Privileged",
+                        "PublishAllPorts",
+                        "ReadonlyRootfs",
+                        "SecurityOpt",
+                        "UTSMode",
+                        "ShmSize",
+                        "ConsoleSize",
+                        "Isolation",
+                        "Resources"
+                    ]
+                },
+                "HostnamePath": {
+                    "type": "string"
+                },
+                "HostsPath": {
+                    "type": "string"
+                },
+                "Id": {
+                    "type": "string"
+                },
+                "Image": {
+                    "type": "string"
+                },
+                "LogPath": {
+                    "type": "string"
+                },
+                "MountLabel": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Path": {
+                    "type": "string"
+                },
+                "ProcessLabel": {
+                    "type": "string"
+                },
+                "ResolvConfPath": {
+                    "type": "string"
+                },
+                "RestartCount": {
+                    "type": "integer"
+                },
+                "SizeRootFs": {
+                    "type": "integer"
+                },
+                "SizeRw": {
+                    "type": "integer"
+                },
+                "State": {
+                    "type": "object",
+                    "properties": {
+                        "Dead": {
+                            "type": "bool"
+                        },
+                        "Error": {
+                            "type": "string"
+                        },
+                        "ExitCode": {
+                            "type": "integer"
+                        },
+                        "FinishedAt": {
+                            "type": "string"
+                        },
+                        "OOMKilled": {
+                            "type": "bool"
+                        },
+                        "Paused": {
+                            "type": "bool"
+                        },
+                        "Pid": {
+                            "type": "integer"
+                        },
+                        "Restarting": {
+                            "type": "bool"
+                        },
+                        "Running": {
+                            "type": "bool"
+                        },
+                        "StartedAt": {
+                            "type": "string"
+                        },
+                        "Status": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "Status",
+                        "Running",
+                        "Paused",
+                        "Restarting",
+                        "OOMKilled",
+                        "Dead",
+                        "Pid",
+                        "ExitCode",
+                        "Error",
+                        "StartedAt",
+                        "FinishedAt"
+                    ]
+                }
+            },
+            "required": [
+                "Id",
+                "Created",
+                "Path",
+                "Args",
+                "State",
+                "Image",
+                "ResolvConfPath",
+                "HostnamePath",
+                "HostsPath",
+                "LogPath",
+                "Name",
+                "RestartCount",
+                "Driver",
+                "MountLabel",
+                "ProcessLabel",
+                "AppArmorProfile",
+                "ExecIDs",
+                "HostConfig",
+                "GraphDriver"
+            ]
+        },
+        "Mounts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Destination": {
+                        "type": "string"
+                    },
+                    "Driver": {
+                        "type": "string"
+                    },
+                    "Mode": {
+                        "type": "string"
+                    },
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Propagation": {
+                        "type": "string"
+                    },
+                    "RW": {
+                        "type": "bool"
+                    },
+                    "Source": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "Source",
+                    "Destination",
+                    "Mode",
+                    "RW",
+                    "Propagation"
+                ]
+            }
+        },
+        "NetworkSettings": {
+            "type": "object",
+            "properties": {
+                "DefaultNetworkSettings": {
+                    "type": "object",
+                    "properties": {
+                        "EndpointID": {
+                            "type": "string"
+                        },
+                        "Gateway": {
+                            "type": "string"
+                        },
+                        "GlobalIPv6Address": {
+                            "type": "string"
+                        },
+                        "GlobalIPv6PrefixLen": {
+                            "type": "integer"
+                        },
+                        "IPAddress": {
+                            "type": "string"
+                        },
+                        "IPPrefixLen": {
+                            "type": "integer"
+                        },
+                        "IPv6Gateway": {
+                            "type": "string"
+                        },
+                        "MacAddress": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "EndpointID",
+                        "Gateway",
+                        "GlobalIPv6Address",
+                        "GlobalIPv6PrefixLen",
+                        "IPAddress",
+                        "IPPrefixLen",
+                        "IPv6Gateway",
+                        "MacAddress"
+                    ]
+                },
+                "NetworkSettingsBase": {
+                    "type": "object",
+                    "properties": {
+                        "Bridge": {
+                            "type": "string"
+                        },
+                        "HairpinMode": {
+                            "type": "bool"
+                        },
+                        "LinkLocalIPv6Address": {
+                            "type": "string"
+                        },
+                        "LinkLocalIPv6PrefixLen": {
+                            "type": "integer"
+                        },
+                        "Ports": {
+                            "type": "object",
+                            "properties": {
+                                ".*": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "SandboxID": {
+                            "type": "string"
+                        },
+                        "SandboxKey": {
+                            "type": "string"
+                        },
+                        "SecondaryIPAddresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "Addr": {
+                                        "type": "string"
+                                    },
+                                    "PrefixLen": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "Addr",
+                                    "PrefixLen"
+                                ]
+                            }
+                        },
+                        "SecondaryIPv6Addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "Addr": {
+                                        "type": "string"
+                                    },
+                                    "PrefixLen": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "Addr",
+                                    "PrefixLen"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "Bridge",
+                        "SandboxID",
+                        "HairpinMode",
+                        "LinkLocalIPv6Address",
+                        "LinkLocalIPv6PrefixLen",
+                        "Ports",
+                        "SandboxKey",
+                        "SecondaryIPAddresses",
+                        "SecondaryIPv6Addresses"
+                    ]
+                },
+                "Networks": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            },
+            "required": [
+                "NetworkSettingsBase",
+                "DefaultNetworkSettings",
+                "Networks"
+            ]
+        }
+    },
+    "required": [
+        "ContainerJSONBase",
+        "Mounts",
+        "Config",
+        "NetworkSettings"
+    ]
+}

--- a/schema/json/master/login.json
+++ b/schema/json/master/login.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Status": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Status"
+    ]
+}

--- a/schema/json/master/network-create.json
+++ b/schema/json/master/network-create.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Id": {
+            "type": "string"
+        },
+        "Warning": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Id",
+        "Warning"
+    ]
+}

--- a/schema/json/master/network-inspect.json
+++ b/schema/json/master/network-inspect.json
@@ -1,0 +1,97 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Containers": {
+            "type": "object",
+            "properties": {
+                ".*": {
+                    "type": "object"
+                }
+            }
+        },
+        "Driver": {
+            "type": "string"
+        },
+        "EnableIPv6": {
+            "type": "bool"
+        },
+        "IPAM": {
+            "type": "object",
+            "properties": {
+                "Config": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "AuxiliaryAddresses": {
+                                "type": "object",
+                                "properties": {
+                                    ".*": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "Gateway": {
+                                "type": "string"
+                            },
+                            "IPRange": {
+                                "type": "string"
+                            },
+                            "Subnet": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "Driver": {
+                    "type": "string"
+                },
+                "Options": {
+                    "type": "object",
+                    "properties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "Driver",
+                "Options",
+                "Config"
+            ]
+        },
+        "Id": {
+            "type": "string"
+        },
+        "Internal": {
+            "type": "bool"
+        },
+        "Name": {
+            "type": "string"
+        },
+        "Options": {
+            "type": "object",
+            "properties": {
+                ".*": {
+                    "type": "string"
+                }
+            }
+        },
+        "Scope": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Name",
+        "Id",
+        "Scope",
+        "Driver",
+        "EnableIPv6",
+        "IPAM",
+        "Internal",
+        "Containers",
+        "Options"
+    ]
+}

--- a/schema/json/master/network-ls.json
+++ b/schema/json/master/network-ls.json
@@ -1,0 +1,100 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Containers": {
+                "type": "object",
+                "properties": {
+                    ".*": {
+                        "type": "object"
+                    }
+                }
+            },
+            "Driver": {
+                "type": "string"
+            },
+            "EnableIPv6": {
+                "type": "bool"
+            },
+            "IPAM": {
+                "type": "object",
+                "properties": {
+                    "Config": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "AuxiliaryAddresses": {
+                                    "type": "object",
+                                    "properties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "Gateway": {
+                                    "type": "string"
+                                },
+                                "IPRange": {
+                                    "type": "string"
+                                },
+                                "Subnet": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "Driver": {
+                        "type": "string"
+                    },
+                    "Options": {
+                        "type": "object",
+                        "properties": {
+                            ".*": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "Driver",
+                    "Options",
+                    "Config"
+                ]
+            },
+            "Id": {
+                "type": "string"
+            },
+            "Internal": {
+                "type": "bool"
+            },
+            "Name": {
+                "type": "string"
+            },
+            "Options": {
+                "type": "object",
+                "properties": {
+                    ".*": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Scope": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "Name",
+            "Id",
+            "Scope",
+            "Driver",
+            "EnableIPv6",
+            "IPAM",
+            "Internal",
+            "Containers",
+            "Options"
+        ]
+    }
+}

--- a/schema/json/master/ps.json
+++ b/schema/json/master/ps.json
@@ -1,0 +1,108 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Command": {
+                "type": "string"
+            },
+            "Created": {
+                "type": "integer"
+            },
+            "HostConfig": {
+                "type": "object",
+                "properties": {
+                    "NetworkMode": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Id": {
+                "type": "string"
+            },
+            "Image": {
+                "type": "string"
+            },
+            "ImageID": {
+                "type": "string"
+            },
+            "Labels": {
+                "type": "object",
+                "properties": {
+                    ".*": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Names": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "NetworkSettings": {
+                "type": "object",
+                "properties": {
+                    "Networks": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                },
+                "required": [
+                    "Networks"
+                ]
+            },
+            "Ports": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "IP": {
+                            "type": "string"
+                        },
+                        "PrivatePort": {
+                            "type": "integer"
+                        },
+                        "PublicPort": {
+                            "type": "integer"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "PrivatePort",
+                        "Type"
+                    ]
+                }
+            },
+            "SizeRootFs": {
+                "type": "integer"
+            },
+            "SizeRw": {
+                "type": "integer"
+            },
+            "State": {
+                "type": "string"
+            },
+            "Status": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "Id",
+            "Names",
+            "Image",
+            "ImageID",
+            "Command",
+            "Created",
+            "Ports",
+            "Labels",
+            "State",
+            "Status",
+            "HostConfig",
+            "NetworkSettings"
+        ]
+    }
+}

--- a/schema/json/master/search.json
+++ b/schema/json/master/search.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "description": {
+                "type": "string"
+            },
+            "is_automated": {
+                "type": "bool"
+            },
+            "is_official": {
+                "type": "bool"
+            },
+            "is_trusted": {
+                "type": "bool"
+            },
+            "name": {
+                "type": "string"
+            },
+            "star_count": {
+                "type": "integer"
+            }
+        },
+        "required": [
+            "star_count",
+            "is_official",
+            "name",
+            "is_trusted",
+            "is_automated",
+            "description"
+        ]
+    }
+}

--- a/schema/json/master/stats.json
+++ b/schema/json/master/stats.json
@@ -1,0 +1,494 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "blkio_stats": {
+                "type": "object",
+                "properties": {
+                    "io_merged_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "io_queue_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "io_service_bytes_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "io_service_time_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "io_serviced_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "io_time_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "io_wait_time_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    },
+                    "sectors_recursive": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "minor": {
+                                    "type": "integer"
+                                },
+                                "op": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "major",
+                                "minor",
+                                "op",
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "io_service_bytes_recursive",
+                    "io_serviced_recursive",
+                    "io_queue_recursive",
+                    "io_service_time_recursive",
+                    "io_wait_time_recursive",
+                    "io_merged_recursive",
+                    "io_time_recursive",
+                    "sectors_recursive"
+                ]
+            },
+            "cpu_stats": {
+                "type": "object",
+                "properties": {
+                    "cpu_usage": {
+                        "type": "object",
+                        "properties": {
+                            "percpu_usage": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                }
+                            },
+                            "total_usage": {
+                                "type": "integer"
+                            },
+                            "usage_in_kernelmode": {
+                                "type": "integer"
+                            },
+                            "usage_in_usermode": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "total_usage",
+                            "percpu_usage",
+                            "usage_in_kernelmode",
+                            "usage_in_usermode"
+                        ]
+                    },
+                    "system_cpu_usage": {
+                        "type": "integer"
+                    },
+                    "throttling_data": {
+                        "type": "object",
+                        "properties": {
+                            "periods": {
+                                "type": "integer"
+                            },
+                            "throttled_periods": {
+                                "type": "integer"
+                            },
+                            "throttled_time": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "periods",
+                            "throttled_periods",
+                            "throttled_time"
+                        ]
+                    }
+                },
+                "required": [
+                    "cpu_usage",
+                    "system_cpu_usage"
+                ]
+            },
+            "memory_stats": {
+                "type": "object",
+                "properties": {
+                    "failcnt": {
+                        "type": "integer"
+                    },
+                    "limit": {
+                        "type": "integer"
+                    },
+                    "max_usage": {
+                        "type": "integer"
+                    },
+                    "stats": {
+                        "type": "object",
+                        "properties": {
+                            ".*": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "usage": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "usage",
+                    "max_usage",
+                    "stats",
+                    "failcnt",
+                    "limit"
+                ]
+            },
+            "pids_stats": {
+                "type": "object",
+                "properties": {
+                    "current": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "precpu_stats": {
+                "type": "object",
+                "properties": {
+                    "cpu_usage": {
+                        "type": "object",
+                        "properties": {
+                            "percpu_usage": {
+                                "type": "array",
+                                "items": {
+                                    "type": "integer"
+                                }
+                            },
+                            "total_usage": {
+                                "type": "integer"
+                            },
+                            "usage_in_kernelmode": {
+                                "type": "integer"
+                            },
+                            "usage_in_usermode": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "total_usage",
+                            "percpu_usage",
+                            "usage_in_kernelmode",
+                            "usage_in_usermode"
+                        ]
+                    },
+                    "system_cpu_usage": {
+                        "type": "integer"
+                    },
+                    "throttling_data": {
+                        "type": "object",
+                        "properties": {
+                            "periods": {
+                                "type": "integer"
+                            },
+                            "throttled_periods": {
+                                "type": "integer"
+                            },
+                            "throttled_time": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "periods",
+                            "throttled_periods",
+                            "throttled_time"
+                        ]
+                    }
+                },
+                "required": [
+                    "cpu_usage",
+                    "system_cpu_usage"
+                ]
+            },
+            "read": {
+                "type": "object",
+                "properties": {
+                    "loc": {
+                        "type": "object",
+                        "properties": {
+                            "cacheEnd": {
+                                "type": "integer"
+                            },
+                            "cacheStart": {
+                                "type": "integer"
+                            },
+                            "cacheZone": {
+                                "type": "object",
+                                "properties": {
+                                    "isDST": {
+                                        "type": "bool"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "offset": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "offset",
+                                    "isDST"
+                                ]
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "tx": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "index": {
+                                            "type": "integer"
+                                        },
+                                        "isstd": {
+                                            "type": "bool"
+                                        },
+                                        "isutc": {
+                                            "type": "bool"
+                                        },
+                                        "when": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "when",
+                                        "index",
+                                        "isstd",
+                                        "isutc"
+                                    ]
+                                }
+                            },
+                            "zone": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "isDST": {
+                                            "type": "bool"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "offset": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "offset",
+                                        "isDST"
+                                    ]
+                                }
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "zone",
+                            "tx",
+                            "cacheStart",
+                            "cacheEnd",
+                            "cacheZone"
+                        ]
+                    },
+                    "nsec": {
+                        "type": "integer"
+                    },
+                    "sec": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "sec",
+                    "nsec",
+                    "loc"
+                ]
+            }
+        },
+        "required": [
+            "read"
+        ]
+    }
+}

--- a/schema/json/master/top.json
+++ b/schema/json/master/top.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Processes": {
+            "type": "array",
+            "items": {
+                "type": "array"
+            }
+        },
+        "Titles": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "Processes",
+        "Titles"
+    ]
+}

--- a/schema/json/master/volume-ls.json
+++ b/schema/json/master/volume-ls.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Volumes": {
+            "type": "array"
+        },
+        "Warnings": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "Volumes",
+        "Warnings"
+    ]
+}

--- a/schema/json/master/volume.json
+++ b/schema/json/master/volume.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Driver": {
+            "type": "string"
+        },
+        "Mountpoint": {
+            "type": "string"
+        },
+        "Name": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Name",
+        "Driver",
+        "Mountpoint"
+    ]
+}

--- a/schema/json/master/wait.json
+++ b/schema/json/master/wait.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "StatusCode": {
+            "type": "integer"
+        }
+    },
+    "required": [
+        "StatusCode"
+    ]
+}


### PR DESCRIPTION
We could validate API responses if we had these schemas, but this is just a PoC.

- Add script to generate JSON schema.

Signed-off-by: David Calavera <david.calavera@gmail.com>