### PR TITLE
Add unit tests for containerInspect

### DIFF
--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerInspectError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte("Server error"))),
+			}, nil
+		}),
+	}
+
+	_, err := client.ContainerInspect("nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerInspectContainerNotFound(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	_, err := client.ContainerInspect("unknown")
+	if err == nil || !IsErrContainerNotFound(err) {
+		t.Fatalf("expected a containerNotFound error, got %v", err)
+	}
+}
+
+func TestContainerInspect(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			content, err := json.Marshal(types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    "container_id",
+					Image: "image",
+					Name:  "name",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+
+	r, err := client.ContainerInspect("container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != "container_id" {
+		t.Fatalf("expected `container_id`, got %s", r.ID)
+	}
+	if r.Image != "image" {
+		t.Fatalf("expected `image`, got %s", r.ID)
+	}
+	if r.Name != "name" {
+		t.Fatalf("expected `name`, got %s", r.ID)
+	}
+}


### PR DESCRIPTION
Wrote a unit test for `ContainerInspect` 🐨 based on the current one (`ContainerStart`).

I was wondering if I should split it into 3 tests or not (my heads tells me it should be 3 unit tests, my finger were lazy :sweat_smile:).

/cc @calavera 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>