### PR TITLE
Add more unit tests to ContainerX methods

### DIFF
--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerCommitError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerCommit(types.ContainerCommitOptions{
+		ContainerID: "nothing",
+	})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerCommit(t *testing.T) {
+	expectedContainerID := "container_id"
+	expectedRepositoryName := "repository_name"
+	expectedTag := "tag"
+	expectedComment := "comment"
+	expectedAuthor := "author"
+	expectedChanges := []string{"change1", "change2"}
+
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			query := req.URL.Query()
+			containerID := query.Get("container")
+			if containerID != expectedContainerID {
+				return nil, fmt.Errorf("container id not set in URL query properly. Expected '%s', got %s", expectedContainerID, containerID)
+			}
+			repo := query.Get("repo")
+			if repo != expectedRepositoryName {
+				return nil, fmt.Errorf("container repo not set in URL query properly. Expected '%s', got %s", expectedRepositoryName, repo)
+			}
+			tag := query.Get("tag")
+			if tag != expectedTag {
+				return nil, fmt.Errorf("container tag not set in URL query properly. Expected '%s', got %s'", expectedTag, tag)
+			}
+			comment := query.Get("comment")
+			if comment != expectedComment {
+				return nil, fmt.Errorf("container comment not set in URL query properly. Expected '%s', got %s'", expectedComment, comment)
+			}
+			author := query.Get("author")
+			if author != expectedAuthor {
+				return nil, fmt.Errorf("container author not set in URL query properly. Expected '%s', got %s'", expectedAuthor, author)
+			}
+			pause := query.Get("pause")
+			if pause != "0" {
+				return nil, fmt.Errorf("container pause not set in URL query properly. Expected 'true', got %v'", pause)
+			}
+			changes := query["changes"]
+			if len(changes) != len(expectedChanges) {
+				return nil, fmt.Errorf("expected container changes size to be '%d', got %d", len(expectedChanges), len(changes))
+			}
+			b, err := json.Marshal(types.ContainerCommitResponse{
+				ID: "new_container_id",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	r, err := client.ContainerCommit(types.ContainerCommitOptions{
+		ContainerID:    expectedContainerID,
+		RepositoryName: expectedRepositoryName,
+		Tag:            expectedTag,
+		Comment:        expectedComment,
+		Author:         expectedAuthor,
+		Changes:        expectedChanges,
+		Pause:          false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != "new_container_id" {
+		t.Fatalf("expected `container_id`, got %s", r.ID)
+	}
+}

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerDiffError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerDiff("nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+
+}
+
+func TestContainerDiff(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			b, err := json.Marshal([]types.ContainerChange{
+				{
+					Kind: 0,
+					Path: "/path/1",
+				},
+				{
+					Kind: 1,
+					Path: "/path/2",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	changes, err := client.ContainerDiff("container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("expected an array of 2 changes, got %v", changes)
+	}
+}

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerExecCreateError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerExecCreate(types.ExecConfig{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerExecCreate(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			// FIXME validate the content is the given ExecConfig ?
+			if err := req.ParseForm(); err != nil {
+				return nil, err
+			}
+			execConfig := &types.ExecConfig{}
+			if err := json.NewDecoder(req.Body).Decode(execConfig); err != nil {
+				return nil, err
+			}
+			if execConfig.Container != "container_id" {
+				return nil, fmt.Errorf("expected an execConfig with Container == 'container_id', got %v", execConfig)
+			}
+			b, err := json.Marshal(types.ContainerExecCreateResponse{
+				ID: "exec_id",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	r, err := client.ContainerExecCreate(types.ExecConfig{
+		Container: "container_id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != "exec_id" {
+		t.Fatalf("expected `exec_id`, got %s", r.ID)
+	}
+}
+
+func TestContainerExecStartError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerExecStart("nothing", types.ExecStartCheck{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerExecStart(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if err := req.ParseForm(); err != nil {
+				return nil, err
+			}
+			execStartCheck := &types.ExecStartCheck{}
+			if err := json.NewDecoder(req.Body).Decode(execStartCheck); err != nil {
+				return nil, err
+			}
+			if execStartCheck.Tty || !execStartCheck.Detach {
+				return nil, fmt.Errorf("expected execStartCheck{Detach:true,Tty:false}, got %v", execStartCheck)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerExecStart("exec_id", types.ExecStartCheck{
+		Detach: true,
+		Tty:    false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContainerExecInspectError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerExecInspect("nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerExecInspect(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			b, err := json.Marshal(types.ContainerExecInspect{
+				ExecID:      "exec_id",
+				ContainerID: "container_id",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	inspect, err := client.ContainerExecInspect("exec_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspect.ExecID != "exec_id" {
+		t.Fatalf("expected ExecID to be `exec_id`, got %s", inspect.ExecID)
+	}
+	if inspect.ContainerID != "container_id" {
+		t.Fatalf("expected ContainerID `container_id`, got %s", inspect.ContainerID)
+	}
+}

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -13,12 +13,7 @@ import (
 
 func TestContainerInspectError(t *testing.T) {
 	client := &Client{
-		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("Server error"))),
-			}, nil
-		}),
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
 	}
 
 	_, err := client.ContainerInspect("nothing")
@@ -29,12 +24,7 @@ func TestContainerInspectError(t *testing.T) {
 
 func TestContainerInspectContainerNotFound(t *testing.T) {
 	client := &Client{
-		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusNotFound, "Server error")),
 	}
 
 	_, err := client.ContainerInspect("unknown")

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerKillError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerKill("nothing", "SIGKILL")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerKill(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			signal := req.URL.Query().Get("signal")
+			if signal != "SIGKILL" {
+				return nil, fmt.Errorf("signal not set in URL query properly. Expected 'SIGKILL', got %s", signal)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerKill("container_id", "SIGKILL")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/transport/client_mock.go
+++ b/client/transport/client_mock.go
@@ -3,7 +3,9 @@
 package transport
 
 import (
+	"bytes"
 	"crypto/tls"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -23,4 +25,13 @@ func NewMockClient(tlsConfig *tls.Config, doer func(*http.Request) (*http.Respon
 // Do executes the supplied function for the mock.
 func (m mockClient) Do(req *http.Request) (*http.Response, error) {
 	return m.do(req)
+}
+
+func ErrorMock(statusCode int, message string) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(message))),
+		}, nil
+	}
 }


### PR DESCRIPTION
Add more unit tests to client methods 🐹 :

- Complete `ContainerCreate`
- `ContainerCommit`
- `ContainerDiff`
- `ContainerExecCreate`
- `ContainerExecStart`
- `ContainerExecInspect`
- Update `ContainerInspect`
- `ContainerKill`

Also added a `transport.ErrorMock` function to write a little bit less for error cases. 🐊

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>