### PR TITLE
Omit empty auth value serializing configuration.

### DIFF
--- a/types/auth.go
+++ b/types/auth.go
@@ -4,7 +4,7 @@ package types
 type AuthConfig struct {
 	Username      string `json:"username,omitempty"`
 	Password      string `json:"password,omitempty"`
-	Auth          string `json:"auth"`
+	Auth          string `json:"auth,omitempty"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
 	RegistryToken string `json:"registrytoken,omitempty"`


### PR DESCRIPTION
Do not serialize auth credentials when the auth field is empty. This works with https://github.com/docker/docker/pull/20107 where we're making this field optional since credentials can be stored in an external store, like the OS X keychain.

Signed-off-by: David Calavera <david.calavera@gmail.com>