### PR TITLE
Add userns to run flags

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -65,6 +65,30 @@ func (n IpcMode) Container() string {
 	return ""
 }
 
+// UsernsMode represents userns mode in the container.
+type UsernsMode string
+
+// IsHost indicates whether the container uses the host's userns.
+func (n UsernsMode) IsHost() bool {
+	return n == "host"
+}
+
+// IsPrivate indicates whether the container uses the a private userns.
+func (n UsernsMode) IsPrivate() bool {
+	return !(n.IsHost())
+}
+
+// Valid indicates whether the userns is valid.
+func (n UsernsMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	default:
+		return false
+	}
+	return true
+}
+
 // UTSMode represents the UTS namespace of the container.
 type UTSMode string
 


### PR DESCRIPTION
Following the discussions in #20111, #19995 and #17409 we need a
mechinshem to enable skipping userns flag when userns re-mapping was
specified in the daemon level.
As suggest by #mrunalp, a coherent and consistent options is to add the
userns flag to the engine-api.

I've also moved the UT found at:
/docker/docker/runconfig/hostconfig_test.go next to hostconfig.go file
(since they test the specified functionality).