### PR TITLE
Expose container mounts in PS structure.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -148,6 +148,7 @@ type Container struct {
 		NetworkMode string `json:",omitempty"`
 	}
 	NetworkSettings *SummaryNetworkSettings
+	Mounts          []MountPoint
 }
 
 // CopyConfig contains request body of Remote API:


### PR DESCRIPTION
This change compliments docker/docker#20017.
It's similar to the NetworkSettings we already expose in the PS structure.

Signed-off-by: David Calavera <david.calavera@gmail.com>