### PR TITLE
Add more unit tests to ContainerX

### DIFF
--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+
+	"golang.org/x/net/context"
+)
+
+func TestContainerExportError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerExport(context.Background(), "nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+)
+
+func TestContainerListError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerList(types.ContainerListOptions{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerList(t *testing.T) {
+	expectedURL := "/containers/json"
+	expectedFilters := `{"before":{"container":true},"label":{"label1":true,"label2":true}}`
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			all := query.Get("all")
+			if all != "1" {
+				return nil, fmt.Errorf("all not set in URL query properly. Expected '1', got %s", all)
+			}
+			limit := query.Get("limit")
+			if limit != "0" {
+				return nil, fmt.Errorf("limit should have not be present in query. Expected '0', got %s", limit)
+			}
+			since := query.Get("since")
+			if since != "container" {
+				return nil, fmt.Errorf("since not set in URL query properly. Expected 'container', got %s", since)
+			}
+			before := query.Get("before")
+			if before != "" {
+				return nil, fmt.Errorf("before should have not be present in query, go %s", before)
+			}
+			size := query.Get("size")
+			if size != "1" {
+				return nil, fmt.Errorf("size not set in URL query properly. Expected '1', got %s", size)
+			}
+			filters := query.Get("filters")
+			if filters != expectedFilters {
+				return nil, fmt.Errorf("expected filters incoherent '%v' with actual filters %v", expectedFilters, filters)
+			}
+
+			b, err := json.Marshal([]types.Container{
+				{
+					ID: "container_id1",
+				},
+				{
+					ID: "container_id2",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	filters := filters.NewArgs()
+	filters.Add("label", "label1")
+	filters.Add("label", "label2")
+	filters.Add("before", "container")
+	containers, err := client.ContainerList(types.ContainerListOptions{
+		Size:   true,
+		All:    true,
+		Since:  "container",
+		Filter: filters,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(containers) != 2 {
+		t.Fatalf("expected 2 containers, got %v", containers)
+	}
+}

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -3,13 +3,26 @@ package client
 import (
 	"io"
 	"log"
+	"net/http"
 	"os"
+	"testing"
 	"time"
 
+	"github.com/docker/engine-api/client/transport"
 	"github.com/docker/engine-api/types"
 
 	"golang.org/x/net/context"
 )
+
+func TestContainerLogsError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerLogs(context.Background(), types.ContainerLogsOptions{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
 
 func ExampleClient_ContainerLogs_withTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerPauseError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerPause("nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerPause(t *testing.T) {
+	expectedURL := "/containers/container_id/pause"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+	err := client.ContainerPause("container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerRemoveError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerRemove(types.ContainerRemoveOptions{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerRemove(t *testing.T) {
+	expectedURL := "/containers/container_id"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			volume := query.Get("v")
+			if volume != "1" {
+				return nil, fmt.Errorf("v (volume) not set in URL query properly. Expected '1', got %s", volume)
+			}
+			force := query.Get("force")
+			if force != "1" {
+				return nil, fmt.Errorf("force not set in URL query properly. Expected '1', got %s", force)
+			}
+			link := query.Get("link")
+			if link != "" {
+				return nil, fmt.Errorf("link should have not be present in query, go %s", link)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerRemove(types.ContainerRemoveOptions{
+		ContainerID:   "container_id",
+		RemoveVolumes: true,
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerRenameError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerRename("nothing", "newNothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerRename(t *testing.T) {
+	expectedURL := "/containers/container_id/rename"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			name := req.URL.Query().Get("name")
+			if name != "newName" {
+				return nil, fmt.Errorf("name not set in URL query properly. Expected 'newName', got %s", name)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerRename("container_id", "newName")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerResizeError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerResize(types.ResizeOptions{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerExecResizeError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerExecResize(types.ResizeOptions{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerResize(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, resizeTransport("/containers/container_id/resize")),
+	}
+
+	err := client.ContainerResize(types.ResizeOptions{
+		ID:     "container_id",
+		Height: 500,
+		Width:  600,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestContainerExecResize(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, resizeTransport("/exec/exec_id/resize")),
+	}
+
+	err := client.ContainerExecResize(types.ResizeOptions{
+		ID:     "exec_id",
+		Height: 500,
+		Width:  600,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func resizeTransport(expectedURL string) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		query := req.URL.Query()
+		h := query.Get("h")
+		if h != "500" {
+			return nil, fmt.Errorf("h not set in URL query properly. Expected '500', got %s", h)
+		}
+		w := query.Get("w")
+		if w != "600" {
+			return nil, fmt.Errorf("w not set in URL query properly. Expected '600', got %s", w)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}
+}

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerRestartError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerRestart("nothing", 0)
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerRestart(t *testing.T) {
+	expectedURL := "/containers/container_id/restart"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			t := req.URL.Query().Get("t")
+			if t != "100" {
+				return nil, fmt.Errorf("t (timeout) not set in URL query properly. Expected '100', got %s", t)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerRestart("container_id", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerStartError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerStart("nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerStart(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerStart("container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+
+	"golang.org/x/net/context"
+)
+
+func TestContainerStatsError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerStats(context.Background(), "nothing", false)
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerStopError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerStop("nothing", 0)
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerStop(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			t := req.URL.Query().Get("t")
+			if t != "100" {
+				return nil, fmt.Errorf("t (timeout) not set in URL query properly. Expected '100', got %s", t)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerStop("container_id", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
+)
+
+func TestContainerTopError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerTop("nothing", []string{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerTop(t *testing.T) {
+	expectedProcesses := [][]string{
+		{"p1", "p2"},
+		{"p3"},
+	}
+	expectedTitles := []string{"title1", "title2"}
+
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			query := req.URL.Query()
+			args := query.Get("ps_args")
+			if args != "arg1 arg2" {
+				return nil, fmt.Errorf("args not set in URL query properly. Expected 'arg1 arg2', got %v", args)
+			}
+
+			b, err := json.Marshal(types.ContainerProcessList{
+				Processes: [][]string{
+					{"p1", "p2"},
+					{"p3"},
+				},
+				Titles: []string{"title1", "title2"},
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	processList, err := client.ContainerTop("container_id", []string{"arg1", "arg2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expectedProcesses, processList.Processes) {
+		t.Fatalf("Processes: expected %v, got %v", expectedProcesses, processList.Processes)
+	}
+	if !reflect.DeepEqual(expectedTitles, processList.Titles) {
+		t.Fatalf("Titles: expected %v, got %v", expectedTitles, processList.Titles)
+	}
+}

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+)
+
+func TestContainerUnpauseError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerUnpause("nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerUnpause(t *testing.T) {
+	expectedURL := "/containers/container_id/unpause"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+	err := client.ContainerUnpause("container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types/container"
+)
+
+func TestContainerUpdateError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerUpdate("nothing", container.UpdateConfig{})
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerUpdate(t *testing.T) {
+	expectedURL := "/containers/container_id/update"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerUpdate("container_id", container.UpdateConfig{
+		Resources: container.Resources{
+			CPUPeriod: 1,
+		},
+		RestartPolicy: container.RestartPolicy{
+			Name: "always",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -1,11 +1,63 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
+	"strings"
+	"testing"
 	"time"
+
+	"github.com/docker/engine-api/client/transport"
+	"github.com/docker/engine-api/types"
 
 	"golang.org/x/net/context"
 )
+
+func TestContainerWaitError(t *testing.T) {
+	client := &Client{
+		transport: transport.NewMockClient(nil, transport.ErrorMock(http.StatusInternalServerError, "Server error")),
+	}
+	code, err := client.ContainerWait(context.Background(), "nothing")
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+	if code != -1 {
+		t.Fatalf("expected a status code equal to '-1', got %d", code)
+	}
+}
+
+func TestContainerWait(t *testing.T) {
+	expectedURL := "/containers/container_id/wait"
+	client := &Client{
+		transport: transport.NewMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			b, err := json.Marshal(types.ContainerWaitResponse{
+				StatusCode: 15,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	code, err := client.ContainerWait(context.Background(), "container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != 15 {
+		t.Fatalf("expected a status code equal to '15', got %d", code)
+	}
+}
 
 func ExampleClient_ContainerWait_withTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Add more unit tests to client methods 🐹 :

- `ContainerExport` (error case only, other cases will follow)
- `ContainerList`
- `ContainerLogs` (error case only, other cases will follow)
- `ContainerPause`
- `ContainerRemove`
- `ContainerRename`
- `ContainerResize`
- `ContainerRestart`
- `ContainerStats` (error case only, other cases will follow)
- `ContainerUnpause`
- `ContainerUpdate`
- `ContainerWait`

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>