### PR TITLE
strslice: refactor StrSlice to avoid unnecessary pointer traversal

### DIFF
--- a/types/container/config.go
+++ b/types/container/config.go
@@ -24,12 +24,12 @@ type Config struct {
 	OpenStdin       bool                  // Open stdin
 	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
 	Env             []string              // List of environment variable to set in the container
-	Cmd             *strslice.StrSlice    // Command to run when starting the container
+	Cmd             strslice.StrSlice     // Command to run when starting the container
 	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
 	Image           string                // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container
 	WorkingDir      string                // Current directory (PWD) in the command will be launched
-	Entrypoint      *strslice.StrSlice    // Entrypoint to run when starting the container
+	Entrypoint      strslice.StrSlice     // Entrypoint to run when starting the container
 	NetworkDisabled bool                  `json:",omitempty"` // Is network disabled
 	MacAddress      string                `json:",omitempty"` // Mac Address of the container
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile

--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -213,24 +213,24 @@ type HostConfig struct {
 	VolumesFrom     []string      // List of volumes to take from other container
 
 	// Applicable to UNIX platforms
-	CapAdd          *strslice.StrSlice // List of kernel capabilities to add to the container
-	CapDrop         *strslice.StrSlice // List of kernel capabilities to remove from the container
-	DNS             []string           `json:"Dns"`        // List of DNS server to lookup
-	DNSOptions      []string           `json:"DnsOptions"` // List of DNSOption to look for
-	DNSSearch       []string           `json:"DnsSearch"`  // List of DNSSearch to look for
-	ExtraHosts      []string           // List of extra hosts
-	GroupAdd        []string           // List of additional groups that the container process will run as
-	IpcMode         IpcMode            // IPC namespace to use for the container
-	Links           []string           // List of links (in the name:alias form)
-	OomScoreAdj     int                // Container preference for OOM-killing
-	PidMode         PidMode            // PID namespace to use for the container
-	Privileged      bool               // Is the container in privileged mode
-	PublishAllPorts bool               // Should docker publish all exposed port for the container
-	ReadonlyRootfs  bool               // Is the container root filesystem in read-only
-	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
-	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
-	UTSMode         UTSMode            // UTS namespace to use for the container
-	ShmSize         int64              // Total shm memory usage
+	CapAdd          strslice.StrSlice // List of kernel capabilities to add to the container
+	CapDrop         strslice.StrSlice // List of kernel capabilities to remove from the container
+	DNS             []string          `json:"Dns"`        // List of DNS server to lookup
+	DNSOptions      []string          `json:"DnsOptions"` // List of DNSOption to look for
+	DNSSearch       []string          `json:"DnsSearch"`  // List of DNSSearch to look for
+	ExtraHosts      []string          // List of extra hosts
+	GroupAdd        []string          // List of additional groups that the container process will run as
+	IpcMode         IpcMode           // IPC namespace to use for the container
+	Links           []string          // List of links (in the name:alias form)
+	OomScoreAdj     int               // Container preference for OOM-killing
+	PidMode         PidMode           // PID namespace to use for the container
+	Privileged      bool              // Is the container in privileged mode
+	PublishAllPorts bool              // Should docker publish all exposed port for the container
+	ReadonlyRootfs  bool              // Is the container root filesystem in read-only
+	SecurityOpt     []string          // List of string values to customize labels for MLS systems, such as SELinux.
+	Tmpfs           map[string]string `json:",omitempty"` // List of tmpfs (mounts) used for the container
+	UTSMode         UTSMode           // UTS namespace to use for the container
+	ShmSize         int64             // Total shm memory usage
 
 	// Applicable to Windows
 	ConsoleSize [2]int    // Initial console size

--- a/types/strslice/strslice.go
+++ b/types/strslice/strslice.go
@@ -7,23 +7,31 @@ import (
 
 // StrSlice represents a string or an array of strings.
 // We need to override the json decoder to accept both options.
-type StrSlice struct {
-	parts []string
-}
+type StrSlice []string
 
 // MarshalJSON Marshals (or serializes) the StrSlice into the json format.
 // This method is needed to implement json.Marshaller.
-func (e *StrSlice) MarshalJSON() ([]byte, error) {
+func (e StrSlice) MarshalJSON() ([]byte, error) {
 	if e == nil {
 		return []byte{}, nil
 	}
-	return json.Marshal(e.Slice())
+
+	if len(e) == 0 {
+		// TODO(stevvooe): This doesn't seem right at all, but the test cases
+		// enforce. Remove if this isn't necessary as this is very unfortunate
+		// behavior.
+		return []byte("null"), nil
+	}
+	return json.Marshal([]string(e))
 }
 
-// UnmarshalJSON decodes the byte slice whether it's a string or an array of strings.
-// This method is needed to implement json.Unmarshaler.
+// UnmarshalJSON decodes the byte slice whether it's a string or an array of
+// strings. This method is needed to implement json.Unmarshaler.
 func (e *StrSlice) UnmarshalJSON(b []byte) error {
 	if len(b) == 0 {
+		// With no input, we preserve the existing value by returning nil and
+		// leaving the target alone. This allows defining default values for
+		// the type.
 		return nil
 	}
 
@@ -36,36 +44,16 @@ func (e *StrSlice) UnmarshalJSON(b []byte) error {
 		p = append(p, s)
 	}
 
-	e.parts = p
+	*e = p
 	return nil
 }
 
-// Len returns the number of parts of the StrSlice.
-func (e *StrSlice) Len() int {
-	if e == nil {
-		return 0
-	}
-	return len(e.parts)
-}
-
-// Slice gets the parts of the StrSlice as a Slice of string.
-func (e *StrSlice) Slice() []string {
-	if e == nil {
-		return nil
-	}
-	return e.parts
-}
-
-// ToString gets space separated string of all the parts.
-func (e *StrSlice) ToString() string {
-	s := e.Slice()
-	if s == nil {
-		return ""
-	}
-	return strings.Join(s, " ")
+// String gets space separated string of all the parts.
+func (e StrSlice) String() string {
+	return strings.Join([]string(e), " ")
 }
 
 // New creates an StrSlice based on the specified parts (as strings).
-func New(parts ...string) *StrSlice {
-	return &StrSlice{parts}
+func New(parts ...string) StrSlice {
+	return StrSlice(parts)
 }

--- a/types/strslice/strslice.go
+++ b/types/strslice/strslice.go
@@ -9,22 +9,6 @@ import (
 // We need to override the json decoder to accept both options.
 type StrSlice []string
 
-// MarshalJSON Marshals (or serializes) the StrSlice into the json format.
-// This method is needed to implement json.Marshaller.
-func (e StrSlice) MarshalJSON() ([]byte, error) {
-	if e == nil {
-		return []byte{}, nil
-	}
-
-	if len(e) == 0 {
-		// TODO(stevvooe): This doesn't seem right at all, but the test cases
-		// enforce. Remove if this isn't necessary as this is very unfortunate
-		// behavior.
-		return []byte("null"), nil
-	}
-	return json.Marshal([]string(e))
-}
-
 // UnmarshalJSON decodes the byte slice whether it's a string or an array of
 // strings. This method is needed to implement json.Unmarshaler.
 func (e *StrSlice) UnmarshalJSON(b []byte) error {

--- a/types/strslice/strslice_test.go
+++ b/types/strslice/strslice_test.go
@@ -11,14 +11,13 @@ func TestStrSliceMarshalJSON(t *testing.T) {
 		input    StrSlice
 		expected string
 	}{
-		{input: nil, expected: ""},
-
 		// MADNESS(stevvooe): No clue why nil would be "" but empty would be
-		// "null". Maintaining compatibility. This is pretty bad.
-		{StrSlice{}, "null"},
+		// "null". Had to make a change here that may affect compatibility.
+		{input: nil, expected: "null"},
+		{StrSlice{}, "[]"},
 		{StrSlice{"/bin/sh", "-c", "echo"}, `["/bin/sh","-c","echo"]`},
 	} {
-		data, err := testcase.input.MarshalJSON()
+		data, err := json.Marshal(testcase.input)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
By removing the struct wrapper around StrSlice, we maintain the slice
properties of the type (len, cap, make, etc.) while overriding the
serialization. We get a simpler type with less pointer traversal.

Signed-off-by: Stephen J Day <stephen.day@docker.com>