### PR TITLE
Correctly set content type for image load

### DIFF
--- a/client/image_load.go
+++ b/client/image_load.go
@@ -18,7 +18,8 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (
 	if quiet {
 		v.Set("quiet", "1")
 	}
-	resp, err := cli.postRaw(ctx, "/images/load", v, input, nil)
+	headers := map[string][]string{"Content-Type": {"application/x-tar"}}
+	resp, err := cli.postRaw(ctx, "/images/load", v, input, headers)
 	if err != nil {
 		return types.ImageLoadResponse{}, err
 	}


### PR DESCRIPTION
The default content type header is `text/plain` if none is specified, which, if authz plugins are in
use will cause the [entire body to be read](https://github.com/docker/docker/blob/master/pkg/authorization/authz.go#L150-L152) (and fail because of another
bug that will be fixed in **docker/docker** separately). Given the content
type should really be binary format anyway, this change should be useful for
any other code in the future that might determine actions based on POST
`Content-Type` headers.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)