### PR TITLE
Remove email from AuthConfig

### DIFF
--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -144,8 +144,7 @@ func TestImageBuild(t *testing.T) {
 			buildOptions: types.ImageBuildOptions{
 				AuthConfigs: map[string]types.AuthConfig{
 					"https://index.docker.io/v1/": {
-						Auth:  "dG90bwo=",
-						Email: "john@doe.com",
+						Auth: "dG90bwo=",
 					},
 				},
 			},
@@ -153,7 +152,7 @@ func TestImageBuild(t *testing.T) {
 				"rm": "0",
 			},
 			expectedTags:           []string{},
-			expectedRegistryConfig: "eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImRHOTBid289IiwiZW1haWwiOiJqb2huQGRvZS5jb20ifX0=",
+			expectedRegistryConfig: "eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImRHOTBid289In19",
 		},
 	}
 	for _, buildCase := range buildCases {

--- a/types/auth.go
+++ b/types/auth.go
@@ -5,7 +5,6 @@ type AuthConfig struct {
 	Username      string `json:"username,omitempty"`
 	Password      string `json:"password,omitempty"`
 	Auth          string `json:"auth,omitempty"`
-	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
 	RegistryToken string `json:"registrytoken,omitempty"`
 }


### PR DESCRIPTION
This change is part of a larger PR on docker engine that will remove email from login, and remove the ability to register from the docker cli.

Related PR: https://github.com/docker/docker/pull/20565

Signed-off-by: Ken Cochrane <KenCochrane@gmail.com>