### PR TITLE
Add support for getting token from login

### DIFF
--- a/types/auth.go
+++ b/types/auth.go
@@ -7,5 +7,11 @@ type AuthConfig struct {
 	Auth          string `json:"auth,omitempty"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
 	RegistryToken string `json:"registrytoken,omitempty"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -39,6 +39,10 @@ type ContainerUpdateResponse struct {
 type AuthResponse struct {
 	// Status is the authentication status
 	Status string `json:"Status"`
+
+	// IdentityToken is an opaque token used for authenticating
+	// a user after a successful login.
+	IdentityToken string `json:"IdentityToken,omitempty"`
 }
 
 // ContainerWaitResponse contains response of Remote API:


### PR DESCRIPTION
The auth response will return an identity token from a login when long lived token authentication is supported. The identity token can be used in the auth config in place of basic authentication to get registry access tokens.

See https://github.com/docker/distribution/pull/1418 for further context on supporting long lived oauth tokens.