### PR TITLE
Remove unnecessary strslice functions

### DIFF
--- a/types/strslice/strslice.go
+++ b/types/strslice/strslice.go
@@ -1,9 +1,6 @@
 package strslice
 
-import (
-	"encoding/json"
-	"strings"
-)
+import "encoding/json"
 
 // StrSlice represents a string or an array of strings.
 // We need to override the json decoder to accept both options.
@@ -30,14 +27,4 @@ func (e *StrSlice) UnmarshalJSON(b []byte) error {
 
 	*e = p
 	return nil
-}
-
-// String gets space separated string of all the parts.
-func (e StrSlice) String() string {
-	return strings.Join([]string(e), " ")
-}
-
-// New creates an StrSlice based on the specified parts (as strings).
-func New(parts ...string) StrSlice {
-	return StrSlice(parts)
 }

--- a/types/strslice/strslice_test.go
+++ b/types/strslice/strslice_test.go
@@ -84,19 +84,3 @@ func TestStrSliceUnmarshalSlice(t *testing.T) {
 		t.Fatalf("expected `echo`, got: %q", e[0])
 	}
 }
-
-func TestStrSliceToString(t *testing.T) {
-	for _, testcase := range []struct {
-		input    StrSlice
-		expected string
-	}{
-		{New(""), ""},
-		{New("one"), "one"},
-		{New("one", "two"), "one two"},
-	} {
-		toString := testcase.input.String()
-		if toString != testcase.expected {
-			t.Fatalf("Expected %v, got %v", testcase.expected, toString)
-		}
-	}
-}


### PR DESCRIPTION
strslice is intended to behave like a string slice with the additional property that when unmarshalled it can handle a string or array.
All over functions are unneeded and allow for misuse of the type.
Currently when output a strslice `fmt.Print` ends up getting used calling the `String()` method which has output which differs from the expected slice output.

Ping @stevvooe @aaronlehmann

Some additional commentary about update process....
This change is needed to properly fix tests when updating the docker vendoring from #97. During this update the need for this additional change was discovered. However now to get the original PR fixed I will need to pull in other changes from this project in order to not break the docker vendor script. Having this project decoupled from docker project has added significant burden to testing and getting further changes in. I do like that changes can merged faster and in isolation from the rest of the docker project but without the ability to integration test this with the main project it only adds more effort to get changes in. To get the original change updated I will either need a branch created with this change cherry-picked or to attempt to merge my changes in the other big change not in master (removing email). For reference #20669 and #20565