### PR TITLE
Removing dead code duplicated in docker/docker

### DIFF
--- a/types/container/hostconfig_windows.go
+++ b/types/container/hostconfig_windows.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -77,20 +76,6 @@ func (n NetworkMode) NetworkName() string {
 	}
 
 	return ""
-}
-
-// ValidateIsolation performs platform specific validation of the
-// isolation technology in the hostconfig structure. Windows supports 'default' (or
-// blank), 'process', or 'hyperv'.
-func ValidateIsolation(hc *HostConfig) error {
-	// We may not be passed a host config, such as in the case of docker commit
-	if hc == nil {
-		return nil
-	}
-	if !hc.Isolation.IsValid() {
-		return fmt.Errorf("invalid --isolation: %q. Windows supports 'default', 'process', or 'hyperv'", hc.Isolation)
-	}
-	return nil
 }
 
 //UserDefined indicates user-created network


### PR DESCRIPTION
As far as I can tell, these functions are duplicated in docker/docker and the docker/docker version is used in all cases. I can submit a parallel PR to docker/docker to confirm that CI passes if needed, but it builds and runs fine locally with these changes.

Signed-off-by: Darren Stahl <darst@microsoft.com>