### PR TITLE
Make email field omitempty for compatibility

### DIFF
--- a/types/auth.go
+++ b/types/auth.go
@@ -2,9 +2,15 @@ package types
 
 // AuthConfig contains authorization information for connecting to a Registry
 type AuthConfig struct {
-	Username      string `json:"username,omitempty"`
-	Password      string `json:"password,omitempty"`
-	Auth          string `json:"auth,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
 	ServerAddress string `json:"serveraddress,omitempty"`
 	RegistryToken string `json:"registrytoken,omitempty"`
 }


### PR DESCRIPTION
Newer instances of auth which do not include an email should not serialize the key,
but existing values should not be stripped on serialization.

Relevant [commentary](https://github.com/docker/docker/pull/20565/files#r54169687) from https://github.com/docker/docker/pull/20565