### PR TITLE
Add `AutoRemove` into HostConfig

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -239,6 +239,7 @@ type HostConfig struct {
 	NetworkMode     NetworkMode   // Network mode to use for the container
 	PortBindings    nat.PortMap   // Port mapping between the exposed port (container) and the host
 	RestartPolicy   RestartPolicy // Restart policy to be used for the container
+	AutoRemove      bool          // Automatically remove container when it exits
 	VolumeDriver    string        // Name of the volume driver used to mount volumes
 	VolumesFrom     []string      // List of volumes to take from other container
 


### PR DESCRIPTION
See https://github.com/docker/docker/pull/20848#issuecomment-191882980

Docker will move `--rm` flag from client side to daemon side, this
demands HostConfig should have a flag for `--rm`.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>