### PR TITLE
client: plumb net/context.Context through entire API

### DIFF
--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -4,13 +4,14 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerAttach attaches a connection to a container in the server.
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerAttach(options types.ContainerAttachOptions) (types.HijackedResponse, error) {
+func (cli *Client) ContainerAttach(ctx context.Context, options types.ContainerAttachOptions) (types.HijackedResponse, error) {
 	query := url.Values{}
 	if options.Stream {
 		query.Set("stream", "1")
@@ -29,5 +30,5 @@ func (cli *Client) ContainerAttach(options types.ContainerAttachOptions) (types.
 	}
 
 	headers := map[string][]string{"Content-Type": {"text/plain"}}
-	return cli.postHijacked("/containers/"+options.ContainerID+"/attach", query, nil, headers)
+	return cli.postHijacked(ctx, "/containers/"+options.ContainerID+"/attach", query, nil, headers)
 }

--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -5,10 +5,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerCommit applies changes into a container and creates a new tagged image.
-func (cli *Client) ContainerCommit(options types.ContainerCommitOptions) (types.ContainerCommitResponse, error) {
+func (cli *Client) ContainerCommit(ctx context.Context, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error) {
 	query := url.Values{}
 	query.Set("container", options.ContainerID)
 	query.Set("repo", options.RepositoryName)
@@ -23,7 +24,7 @@ func (cli *Client) ContainerCommit(options types.ContainerCommitOptions) (types.
 	}
 
 	var response types.ContainerCommitResponse
-	resp, err := cli.post("/commit", query, options.Config, nil)
+	resp, err := cli.post(ctx, "/commit", query, options.Config, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerCommitError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerCommit(types.ContainerCommitOptions{
+	_, err := client.ContainerCommit(context.Background(), types.ContainerCommitOptions{
 		ContainerID: "nothing",
 	})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
@@ -75,7 +76,7 @@ func TestContainerCommit(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ContainerCommit(types.ContainerCommitOptions{
+	r, err := client.ContainerCommit(context.Background(), types.ContainerCommitOptions{
 		ContainerID:    expectedContainerID,
 		RepositoryName: expectedRepositoryName,
 		Tag:            expectedTag,

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -16,12 +16,12 @@ import (
 )
 
 // ContainerStatPath returns Stat information about a path inside the container filesystem.
-func (cli *Client) ContainerStatPath(containerID, path string) (types.ContainerPathStat, error) {
+func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error) {
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
 	urlStr := fmt.Sprintf("/containers/%s/archive", containerID)
-	response, err := cli.head(urlStr, query, nil)
+	response, err := cli.head(ctx, urlStr, query, nil)
 	if err != nil {
 		return types.ContainerPathStat{}, err
 	}
@@ -40,7 +40,7 @@ func (cli *Client) CopyToContainer(ctx context.Context, options types.CopyToCont
 
 	path := fmt.Sprintf("/containers/%s/archive", options.ContainerID)
 
-	response, err := cli.putRawWithContext(ctx, path, query, options.Content, nil)
+	response, err := cli.putRaw(ctx, path, query, options.Content, nil)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
 	apiPath := fmt.Sprintf("/containers/%s/archive", containerID)
-	response, err := cli.getWithContext(ctx, apiPath, query, nil)
+	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
 		return nil, types.ContainerPathStat{}, err
 	}

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
+	"golang.org/x/net/context"
 )
 
 type configWrapper struct {
@@ -18,7 +19,7 @@ type configWrapper struct {
 
 // ContainerCreate creates a new container based in the given configuration.
 // It can be associated with a name, but it's not mandatory.
-func (cli *Client) ContainerCreate(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error) {
+func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error) {
 	var response types.ContainerCreateResponse
 	query := url.Values{}
 	if containerName != "" {
@@ -31,7 +32,7 @@ func (cli *Client) ContainerCreate(config *container.Config, hostConfig *contain
 		NetworkingConfig: networkingConfig,
 	}
 
-	serverResp, err := cli.post("/containers/create", query, body, nil)
+	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
 	if err != nil {
 		if serverResp != nil && serverResp.statusCode == 404 && strings.Contains(err.Error(), "No such image") {
 			return response, imageNotFoundError{config.Image}

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
+	"golang.org/x/net/context"
 )
 
 func TestContainerCreateError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerCreate(nil, nil, nil, "nothing")
+	_, err := client.ContainerCreate(context.Background(), nil, nil, nil, "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -25,7 +26,7 @@ func TestContainerCreateError(t *testing.T) {
 	client = &Client{
 		transport: newMockClient(nil, errorMock(http.StatusNotFound, "Server error")),
 	}
-	_, err = client.ContainerCreate(nil, nil, nil, "nothing")
+	_, err = client.ContainerCreate(context.Background(), nil, nil, nil, "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -35,7 +36,7 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusNotFound, "No such image")),
 	}
-	_, err := client.ContainerCreate(&container.Config{Image: "unknown_image"}, nil, nil, "unknown")
+	_, err := client.ContainerCreate(context.Background(), &container.Config{Image: "unknown_image"}, nil, nil, "unknown")
 	if err == nil || !IsErrImageNotFound(err) {
 		t.Fatalf("expected a imageNotFound error, got %v", err)
 	}
@@ -61,7 +62,7 @@ func TestContainerCreateWithName(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ContainerCreate(nil, nil, nil, "container_name")
+	r, err := client.ContainerCreate(context.Background(), nil, nil, nil, "container_name")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_diff.go
+++ b/client/container_diff.go
@@ -5,13 +5,14 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerDiff shows differences in a container filesystem since it was started.
-func (cli *Client) ContainerDiff(containerID string) ([]types.ContainerChange, error) {
+func (cli *Client) ContainerDiff(ctx context.Context, containerID string) ([]types.ContainerChange, error) {
 	var changes []types.ContainerChange
 
-	serverResp, err := cli.get("/containers/"+containerID+"/changes", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
 	if err != nil {
 		return changes, err
 	}

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerDiffError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerDiff("nothing")
+	_, err := client.ContainerDiff(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -44,7 +45,7 @@ func TestContainerDiff(t *testing.T) {
 		}),
 	}
 
-	changes, err := client.ContainerDiff("container_id")
+	changes, err := client.ContainerDiff(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerExecCreate creates a new exec configuration to run an exec process.
-func (cli *Client) ContainerExecCreate(config types.ExecConfig) (types.ContainerExecCreateResponse, error) {
+func (cli *Client) ContainerExecCreate(ctx context.Context, config types.ExecConfig) (types.ContainerExecCreateResponse, error) {
 	var response types.ContainerExecCreateResponse
-	resp, err := cli.post("/containers/"+config.Container+"/exec", nil, config, nil)
+	resp, err := cli.post(ctx, "/containers/"+config.Container+"/exec", nil, config, nil)
 	if err != nil {
 		return response, err
 	}
@@ -19,8 +20,8 @@ func (cli *Client) ContainerExecCreate(config types.ExecConfig) (types.Container
 }
 
 // ContainerExecStart starts an exec process already create in the docker host.
-func (cli *Client) ContainerExecStart(execID string, config types.ExecStartCheck) error {
-	resp, err := cli.post("/exec/"+execID+"/start", nil, config, nil)
+func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error {
+	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
 	ensureReaderClosed(resp)
 	return err
 }
@@ -29,15 +30,15 @@ func (cli *Client) ContainerExecStart(execID string, config types.ExecStartCheck
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerExecAttach(execID string, config types.ExecConfig) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error) {
 	headers := map[string][]string{"Content-Type": {"application/json"}}
-	return cli.postHijacked("/exec/"+execID+"/start", nil, config, headers)
+	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, headers)
 }
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.
-func (cli *Client) ContainerExecInspect(execID string) (types.ContainerExecInspect, error) {
+func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
 	var response types.ContainerExecInspect
-	resp, err := cli.get("/exec/"+execID+"/json", nil, nil)
+	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerExecCreateError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerExecCreate(types.ExecConfig{})
+	_, err := client.ContainerExecCreate(context.Background(), types.ExecConfig{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -48,7 +49,7 @@ func TestContainerExecCreate(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ContainerExecCreate(types.ExecConfig{
+	r, err := client.ContainerExecCreate(context.Background(), types.ExecConfig{
 		Container: "container_id",
 	})
 	if err != nil {
@@ -63,7 +64,7 @@ func TestContainerExecStartError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerExecStart("nothing", types.ExecStartCheck{})
+	err := client.ContainerExecStart(context.Background(), "nothing", types.ExecStartCheck{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -90,7 +91,7 @@ func TestContainerExecStart(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerExecStart("exec_id", types.ExecStartCheck{
+	err := client.ContainerExecStart(context.Background(), "exec_id", types.ExecStartCheck{
 		Detach: true,
 		Tty:    false,
 	})
@@ -103,7 +104,7 @@ func TestContainerExecInspectError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerExecInspect("nothing")
+	_, err := client.ContainerExecInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -126,7 +127,7 @@ func TestContainerExecInspect(t *testing.T) {
 		}),
 	}
 
-	inspect, err := client.ContainerExecInspect("exec_id")
+	inspect, err := client.ContainerExecInspect(context.Background(), "exec_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_export.go
+++ b/client/container_export.go
@@ -11,7 +11,7 @@ import (
 // and returns them as a io.ReadCloser. It's up to the caller
 // to close the stream.
 func (cli *Client) ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error) {
-	serverResp, err := cli.getWithContext(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -8,11 +8,12 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerInspect returns the container information.
-func (cli *Client) ContainerInspect(containerID string) (types.ContainerJSON, error) {
-	serverResp, err := cli.get("/containers/"+containerID+"/json", nil, nil)
+func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, containerNotFoundError{containerID}
@@ -27,12 +28,12 @@ func (cli *Client) ContainerInspect(containerID string) (types.ContainerJSON, er
 }
 
 // ContainerInspectWithRaw returns the container information and it's raw representation.
-func (cli *Client) ContainerInspectWithRaw(containerID string, getSize bool) (types.ContainerJSON, []byte, error) {
+func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID string, getSize bool) (types.ContainerJSON, []byte, error) {
 	query := url.Values{}
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get("/containers/"+containerID+"/json", query, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, nil, containerNotFoundError{containerID}
@@ -52,8 +53,8 @@ func (cli *Client) ContainerInspectWithRaw(containerID string, getSize bool) (ty
 	return response, body, err
 }
 
-func (cli *Client) containerInspectWithResponse(containerID string, query url.Values) (types.ContainerJSON, *serverResponse, error) {
-	serverResp, err := cli.get("/containers/"+containerID+"/json", nil, nil)
+func (cli *Client) containerInspectWithResponse(ctx context.Context, containerID string, query url.Values) (types.ContainerJSON, *serverResponse, error) {
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		return types.ContainerJSON{}, serverResp, err
 	}

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerInspectError(t *testing.T) {
@@ -15,7 +16,7 @@ func TestContainerInspectError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ContainerInspect("nothing")
+	_, err := client.ContainerInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -26,7 +27,7 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, err := client.ContainerInspect("unknown")
+	_, err := client.ContainerInspect(context.Background(), "unknown")
 	if err == nil || !IsErrContainerNotFound(err) {
 		t.Fatalf("expected a containerNotFound error, got %v", err)
 	}
@@ -52,7 +53,7 @@ func TestContainerInspect(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ContainerInspect("container_id")
+	r, err := client.ContainerInspect(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_kill.go
+++ b/client/container_kill.go
@@ -1,13 +1,17 @@
 package client
 
-import "net/url"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ContainerKill terminates the container process but does not remove the container from the docker host.
-func (cli *Client) ContainerKill(containerID, signal string) error {
+func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string) error {
 	query := url.Values{}
 	query.Set("signal", signal)
 
-	resp, err := cli.post("/containers/"+containerID+"/kill", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -6,13 +6,15 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerKillError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerKill("nothing", "SIGKILL")
+	err := client.ContainerKill(context.Background(), "nothing", "SIGKILL")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -32,7 +34,7 @@ func TestContainerKill(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerKill("container_id", "SIGKILL")
+	err := client.ContainerKill(context.Background(), "container_id", "SIGKILL")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // ContainerList returns the list of containers in the docker host.
-func (cli *Client) ContainerList(options types.ContainerListOptions) ([]types.Container, error) {
+func (cli *Client) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	query := url.Values{}
 
 	if options.All {
@@ -42,7 +43,7 @@ func (cli *Client) ContainerList(options types.ContainerListOptions) ([]types.Co
 		query.Set("filters", filterJSON)
 	}
 
-	resp, err := cli.get("/containers/json", query, nil)
+	resp, err := cli.get(ctx, "/containers/json", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 func TestContainerListError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerList(types.ContainerListOptions{})
+	_, err := client.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -80,7 +81,7 @@ func TestContainerList(t *testing.T) {
 	filters.Add("label", "label1")
 	filters.Add("label", "label2")
 	filters.Add("before", "container")
-	containers, err := client.ContainerList(types.ContainerListOptions{
+	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
 		Size:   true,
 		All:    true,
 		Since:  "container",

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -40,7 +40,7 @@ func (cli *Client) ContainerLogs(ctx context.Context, options types.ContainerLog
 	}
 	query.Set("tail", options.Tail)
 
-	resp, err := cli.getWithContext(ctx, "/containers/"+options.ContainerID+"/logs", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+options.ContainerID+"/logs", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_pause.go
+++ b/client/container_pause.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // ContainerPause pauses the main process of a given container without terminating it.
-func (cli *Client) ContainerPause(containerID string) error {
-	resp, err := cli.post("/containers/"+containerID+"/pause", nil, nil, nil)
+func (cli *Client) ContainerPause(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/pause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -7,13 +7,15 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerPauseError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerPause("nothing")
+	err := client.ContainerPause(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -32,7 +34,7 @@ func TestContainerPause(t *testing.T) {
 			}, nil
 		}),
 	}
-	err := client.ContainerPause("container_id")
+	err := client.ContainerPause(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_remove.go
+++ b/client/container_remove.go
@@ -4,10 +4,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerRemove kills and removes a container from the docker host.
-func (cli *Client) ContainerRemove(options types.ContainerRemoveOptions) error {
+func (cli *Client) ContainerRemove(ctx context.Context, options types.ContainerRemoveOptions) error {
 	query := url.Values{}
 	if options.RemoveVolumes {
 		query.Set("v", "1")
@@ -20,7 +21,7 @@ func (cli *Client) ContainerRemove(options types.ContainerRemoveOptions) error {
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.delete("/containers/"+options.ContainerID, query, nil)
+	resp, err := cli.delete(ctx, "/containers/"+options.ContainerID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerRemoveError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerRemove(types.ContainerRemoveOptions{})
+	err := client.ContainerRemove(context.Background(), types.ContainerRemoveOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -48,7 +49,7 @@ func TestContainerRemove(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerRemove(types.ContainerRemoveOptions{
+	err := client.ContainerRemove(context.Background(), types.ContainerRemoveOptions{
 		ContainerID:   "container_id",
 		RemoveVolumes: true,
 		Force:         true,

--- a/client/container_rename.go
+++ b/client/container_rename.go
@@ -1,12 +1,16 @@
 package client
 
-import "net/url"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // ContainerRename changes the name of a given container.
-func (cli *Client) ContainerRename(containerID, newContainerName string) error {
+func (cli *Client) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
 	query := url.Values{}
 	query.Set("name", newContainerName)
-	resp, err := cli.post("/containers/"+containerID+"/rename", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -7,13 +7,15 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerRenameError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerRename("nothing", "newNothing")
+	err := client.ContainerRename(context.Background(), "nothing", "newNothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -37,7 +39,7 @@ func TestContainerRename(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerRename("container_id", "newName")
+	err := client.ContainerRename(context.Background(), "container_id", "newName")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -5,24 +5,25 @@ import (
 	"strconv"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerResize changes the size of the tty for a container.
-func (cli *Client) ContainerResize(options types.ResizeOptions) error {
-	return cli.resize("/containers/"+options.ID, options.Height, options.Width)
+func (cli *Client) ContainerResize(ctx context.Context, options types.ResizeOptions) error {
+	return cli.resize(ctx, "/containers/"+options.ID, options.Height, options.Width)
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(options types.ResizeOptions) error {
-	return cli.resize("/exec/"+options.ID, options.Height, options.Width)
+func (cli *Client) ContainerExecResize(ctx context.Context, options types.ResizeOptions) error {
+	return cli.resize(ctx, "/exec/"+options.ID, options.Height, options.Width)
 }
 
-func (cli *Client) resize(basePath string, height, width int) error {
+func (cli *Client) resize(ctx context.Context, basePath string, height, width int) error {
 	query := url.Values{}
 	query.Set("h", strconv.Itoa(height))
 	query.Set("w", strconv.Itoa(width))
 
-	resp, err := cli.post(basePath+"/resize", query, nil, nil)
+	resp, err := cli.post(ctx, basePath+"/resize", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerResizeError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerResize(types.ResizeOptions{})
+	err := client.ContainerResize(context.Background(), types.ResizeOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -25,7 +26,7 @@ func TestContainerExecResizeError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerExecResize(types.ResizeOptions{})
+	err := client.ContainerExecResize(context.Background(), types.ResizeOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -36,7 +37,7 @@ func TestContainerResize(t *testing.T) {
 		transport: newMockClient(nil, resizeTransport("/containers/container_id/resize")),
 	}
 
-	err := client.ContainerResize(types.ResizeOptions{
+	err := client.ContainerResize(context.Background(), types.ResizeOptions{
 		ID:     "container_id",
 		Height: 500,
 		Width:  600,
@@ -51,7 +52,7 @@ func TestContainerExecResize(t *testing.T) {
 		transport: newMockClient(nil, resizeTransport("/exec/exec_id/resize")),
 	}
 
-	err := client.ContainerExecResize(types.ResizeOptions{
+	err := client.ContainerExecResize(context.Background(), types.ResizeOptions{
 		ID:     "exec_id",
 		Height: 500,
 		Width:  600,

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -3,15 +3,17 @@ package client
 import (
 	"net/url"
 	"strconv"
+
+	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(containerID string, timeout int) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout int) error {
 	query := url.Values{}
 	query.Set("t", strconv.Itoa(timeout))
-	resp, err := cli.post("/containers/"+containerID+"/restart", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -7,13 +7,15 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerRestartError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerRestart("nothing", 0)
+	err := client.ContainerRestart(context.Background(), "nothing", 0)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -37,7 +39,7 @@ func TestContainerRestart(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerRestart("container_id", 100)
+	err := client.ContainerRestart(context.Background(), "container_id", 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // ContainerStart sends a request to the docker daemon to start a container.
-func (cli *Client) ContainerStart(containerID string) error {
-	resp, err := cli.post("/containers/"+containerID+"/start", nil, nil, nil)
+func (cli *Client) ContainerStart(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -5,13 +5,15 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerStartError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerStart("nothing")
+	err := client.ContainerStart(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -27,7 +29,7 @@ func TestContainerStart(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerStart("container_id")
+	err := client.ContainerStart(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -16,7 +16,7 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 		query.Set("stream", "1")
 	}
 
-	resp, err := cli.getWithContext(ctx, "/containers/"+containerID+"/stats", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -3,14 +3,16 @@ package client
 import (
 	"net/url"
 	"strconv"
+
+	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(containerID string, timeout int) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout int) error {
 	query := url.Values{}
 	query.Set("t", strconv.Itoa(timeout))
-	resp, err := cli.post("/containers/"+containerID+"/stop", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -6,13 +6,15 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerStopError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerStop("nothing", 0)
+	err := client.ContainerStop(context.Background(), "nothing", 0)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -32,7 +34,7 @@ func TestContainerStop(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerStop("container_id", 100)
+	err := client.ContainerStop(context.Background(), "container_id", 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -6,17 +6,18 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ContainerTop shows process information from within a container.
-func (cli *Client) ContainerTop(containerID string, arguments []string) (types.ContainerProcessList, error) {
+func (cli *Client) ContainerTop(ctx context.Context, containerID string, arguments []string) (types.ContainerProcessList, error) {
 	var response types.ContainerProcessList
 	query := url.Values{}
 	if len(arguments) > 0 {
 		query.Set("ps_args", strings.Join(arguments, " "))
 	}
 
-	resp, err := cli.get("/containers/"+containerID+"/top", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/top", query, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -10,13 +10,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestContainerTopError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ContainerTop("nothing", []string{})
+	_, err := client.ContainerTop(context.Background(), "nothing", []string{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -55,7 +56,7 @@ func TestContainerTop(t *testing.T) {
 		}),
 	}
 
-	processList, err := client.ContainerTop("container_id", []string{"arg1", "arg2"})
+	processList, err := client.ContainerTop(context.Background(), "container_id", []string{"arg1", "arg2"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_unpause.go
+++ b/client/container_unpause.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // ContainerUnpause resumes the process execution within a container
-func (cli *Client) ContainerUnpause(containerID string) error {
-	resp, err := cli.post("/containers/"+containerID+"/unpause", nil, nil, nil)
+func (cli *Client) ContainerUnpause(ctx context.Context, containerID string) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/unpause", nil, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -7,13 +7,15 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestContainerUnpauseError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerUnpause("nothing")
+	err := client.ContainerUnpause(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -32,7 +34,7 @@ func TestContainerUnpause(t *testing.T) {
 			}, nil
 		}),
 	}
-	err := client.ContainerUnpause("container_id")
+	err := client.ContainerUnpause(context.Background(), "container_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_update.go
+++ b/client/container_update.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"github.com/docker/engine-api/types/container"
+	"golang.org/x/net/context"
 )
 
 // ContainerUpdate updates resources of a container
-func (cli *Client) ContainerUpdate(containerID string, updateConfig container.UpdateConfig) error {
-	resp, err := cli.post("/containers/"+containerID+"/update", nil, updateConfig, nil)
+func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) error {
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types/container"
+	"golang.org/x/net/context"
 )
 
 func TestContainerUpdateError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerUpdate("nothing", container.UpdateConfig{})
+	err := client.ContainerUpdate(context.Background(), "nothing", container.UpdateConfig{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -35,7 +36,7 @@ func TestContainerUpdate(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerUpdate("container_id", container.UpdateConfig{
+	err := client.ContainerUpdate(context.Background(), "container_id", container.UpdateConfig{
 		Resources: container.Resources{
 			CPUPeriod: 1,
 		},

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -11,7 +11,7 @@ import (
 // ContainerWait pauses execution util a container is exits.
 // It returns the API status code as response of its readiness.
 func (cli *Client) ContainerWait(ctx context.Context, containerID string) (int, error) {
-	resp, err := cli.postWithContext(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/wait", nil, nil, nil)
 	if err != nil {
 		return -1, err
 	}

--- a/client/events.go
+++ b/client/events.go
@@ -40,7 +40,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (io.
 		query.Set("filters", filterJSON)
 	}
 
-	serverResponse, err := cli.getWithContext(ctx, "/events", query, nil)
+	serverResponse, err := cli.get(ctx, "/events", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/go-connections/sockets"
+	"golang.org/x/net/context"
 )
 
 // tlsClientCon holds tls information and a dialed connection.
@@ -30,7 +31,7 @@ func (c *tlsClientCon) CloseWrite() error {
 }
 
 // postHijacked sends a POST request and hijacks the connection.
-func (cli *Client) postHijacked(path string, query url.Values, body interface{}, headers map[string][]string) (types.HijackedResponse, error) {
+func (cli *Client) postHijacked(ctx context.Context, path string, query url.Values, body interface{}, headers map[string][]string) (types.HijackedResponse, error) {
 	bodyEncoded, err := encodeData(body)
 	if err != nil {
 		return types.HijackedResponse{}, err

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -24,5 +24,5 @@ func (cli *Client) ImageCreate(ctx context.Context, options types.ImageCreateOpt
 
 func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (*serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.postWithContext(ctx, "/images/create", query, nil, headers)
+	return cli.post(ctx, "/images/create", query, nil, headers)
 }

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -5,12 +5,13 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageHistory returns the changes in an image in history format.
-func (cli *Client) ImageHistory(imageID string) ([]types.ImageHistory, error) {
+func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]types.ImageHistory, error) {
 	var history []types.ImageHistory
-	serverResp, err := cli.get("/images/"+imageID+"/history", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", url.Values{}, nil)
 	if err != nil {
 		return history, err
 	}

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -10,13 +10,14 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestImageHistoryError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageHistory("nothing")
+	_, err := client.ImageHistory(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
 	}
@@ -49,7 +50,7 @@ func TestImageHistory(t *testing.T) {
 			}, nil
 		}),
 	}
-	imageHistories, err := client.ImageHistory("image_id")
+	imageHistories, err := client.ImageHistory(context.Background(), "image_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/image_import.go
+++ b/client/image_import.go
@@ -21,7 +21,7 @@ func (cli *Client) ImageImport(ctx context.Context, options types.ImageImportOpt
 		query.Add("changes", change)
 	}
 
-	resp, err := cli.postRaw(ctx, "/images/create", query, options.Source, nil)
+	resp, err := cli.post(ctx, "/images/create", query, options.Source, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -6,13 +6,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
-
-	"strings"
-
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestImageImportError(t *testing.T) {

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -8,15 +8,16 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageInspectWithRaw returns the image information and it's raw representation.
-func (cli *Client) ImageInspectWithRaw(imageID string, getSize bool) (types.ImageInspect, []byte, error) {
+func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (types.ImageInspect, []byte, error) {
 	query := url.Values{}
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get("/images/"+imageID+"/json", query, nil)
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ImageInspect{}, nil, imageNotFoundError{imageID}

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestImageInspectError(t *testing.T) {
@@ -18,7 +19,7 @@ func TestImageInspectError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, _, err := client.ImageInspectWithRaw("nothing", true)
+	_, _, err := client.ImageInspectWithRaw(context.Background(), "nothing", true)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -29,7 +30,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, _, err := client.ImageInspectWithRaw("unknown", true)
+	_, _, err := client.ImageInspectWithRaw(context.Background(), "unknown", true)
 	if err == nil || !IsErrImageNotFound(err) {
 		t.Fatalf("expected a imageNotFound error, got %v", err)
 	}
@@ -82,7 +83,7 @@ func TestImageInspect(t *testing.T) {
 			}),
 		}
 
-		imageInspect, _, err := client.ImageInspectWithRaw("image_id", inspectCase.size)
+		imageInspect, _, err := client.ImageInspectWithRaw(context.Background(), "image_id", inspectCase.size)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // ImageList returns a list of images in the docker host.
-func (cli *Client) ImageList(options types.ImageListOptions) ([]types.Image, error) {
+func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error) {
 	var images []types.Image
 	query := url.Values{}
 
@@ -28,7 +29,7 @@ func (cli *Client) ImageList(options types.ImageListOptions) ([]types.Image, err
 		query.Set("all", "1")
 	}
 
-	serverResp, err := cli.get("/images/json", query, nil)
+	serverResp, err := cli.get(ctx, "/images/json", query, nil)
 	if err != nil {
 		return images, err
 	}

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 func TestImageListError(t *testing.T) {
@@ -18,7 +19,7 @@ func TestImageListError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ImageList(types.ImageListOptions{})
+	_, err := client.ImageList(context.Background(), types.ImageListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -110,7 +111,7 @@ func TestImageList(t *testing.T) {
 			}),
 		}
 
-		images, err := client.ImageList(listCase.options)
+		images, err := client.ImageList(context.Background(), listCase.options)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -34,5 +34,5 @@ func (cli *Client) ImagePush(ctx context.Context, options types.ImagePushOptions
 
 func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (*serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.postWithContext(ctx, "/images/"+imageID+"/push", query, nil, headers)
+	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, headers)
 }

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -5,10 +5,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageRemove removes an image from the docker host.
-func (cli *Client) ImageRemove(options types.ImageRemoveOptions) ([]types.ImageDelete, error) {
+func (cli *Client) ImageRemove(ctx context.Context, options types.ImageRemoveOptions) ([]types.ImageDelete, error) {
 	query := url.Values{}
 
 	if options.Force {
@@ -18,7 +19,7 @@ func (cli *Client) ImageRemove(options types.ImageRemoveOptions) ([]types.ImageD
 		query.Set("noprune", "1")
 	}
 
-	resp, err := cli.delete("/images/"+options.ImageID, query, nil)
+	resp, err := cli.delete(ctx, "/images/"+options.ImageID, query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestImageRemoveError(t *testing.T) {
@@ -17,7 +18,7 @@ func TestImageRemoveError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ImageRemove(types.ImageRemoveOptions{})
+	_, err := client.ImageRemove(context.Background(), types.ImageRemoveOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -80,7 +81,7 @@ func TestImageRemove(t *testing.T) {
 				}, nil
 			}),
 		}
-		imageDeletes, err := client.ImageRemove(types.ImageRemoveOptions{
+		imageDeletes, err := client.ImageRemove(context.Background(), types.ImageRemoveOptions{
 			ImageID:       "image_id",
 			Force:         removeCase.force,
 			PruneChildren: removeCase.pruneChildren,

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -14,7 +14,7 @@ func (cli *Client) ImageSave(ctx context.Context, imageIDs []string) (io.ReadClo
 		"names": imageIDs,
 	}
 
-	resp, err := cli.getWithContext(ctx, "/images/get", query, nil)
+	resp, err := cli.get(ctx, "/images/get", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -4,10 +4,11 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ImageTag tags an image in the docker host
-func (cli *Client) ImageTag(options types.ImageTagOptions) error {
+func (cli *Client) ImageTag(ctx context.Context, options types.ImageTagOptions) error {
 	query := url.Values{}
 	query.Set("repo", options.RepositoryName)
 	query.Set("tag", options.Tag)
@@ -15,7 +16,7 @@ func (cli *Client) ImageTag(options types.ImageTagOptions) error {
 		query.Set("force", "1")
 	}
 
-	resp, err := cli.post("/images/"+options.ImageID+"/tag", query, nil, nil)
+	resp, err := cli.post(ctx, "/images/"+options.ImageID+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestImageTagError(t *testing.T) {
@@ -16,7 +17,7 @@ func TestImageTagError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.ImageTag(types.ImageTagOptions{})
+	err := client.ImageTag(context.Background(), types.ImageTagOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -72,7 +73,7 @@ func TestImageTag(t *testing.T) {
 				}, nil
 			}),
 		}
-		err := client.ImageTag(types.ImageTagOptions{
+		err := client.ImageTag(context.Background(), types.ImageTagOptions{
 			ImageID:        "image_id",
 			Force:          tagCase.force,
 			RepositoryName: tagCase.repositoryName,

--- a/client/info.go
+++ b/client/info.go
@@ -6,12 +6,13 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // Info returns information about the docker server.
-func (cli *Client) Info() (types.Info, error) {
+func (cli *Client) Info(ctx context.Context) (types.Info, error) {
 	var info types.Info
-	serverResp, err := cli.get("/info", url.Values{}, nil)
+	serverResp, err := cli.get(ctx, "/info", url.Values{}, nil)
 	if err != nil {
 		return info, err
 	}

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func infoMock(req *http.Request) (*http.Response, error) {
@@ -31,7 +32,7 @@ func TestInfo(t *testing.T) {
 		transport: newMockClient(nil, infoMock),
 	}
 
-	info, err := client.Info()
+	info, err := client.Info(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -15,63 +15,63 @@ import (
 // APIClient is an interface that clients that talk with a docker server must implement.
 type APIClient interface {
 	ClientVersion() string
-	ContainerAttach(options types.ContainerAttachOptions) (types.HijackedResponse, error)
-	ContainerCommit(options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
-	ContainerCreate(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
-	ContainerDiff(containerID string) ([]types.ContainerChange, error)
-	ContainerExecAttach(execID string, config types.ExecConfig) (types.HijackedResponse, error)
-	ContainerExecCreate(config types.ExecConfig) (types.ContainerExecCreateResponse, error)
-	ContainerExecInspect(execID string) (types.ContainerExecInspect, error)
-	ContainerExecResize(options types.ResizeOptions) error
-	ContainerExecStart(execID string, config types.ExecStartCheck) error
+	ContainerAttach(ctx context.Context, options types.ContainerAttachOptions) (types.HijackedResponse, error)
+	ContainerCommit(ctx context.Context, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
+	ContainerDiff(ctx context.Context, ontainerID string) ([]types.ContainerChange, error)
+	ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error)
+	ContainerExecCreate(ctx context.Context, config types.ExecConfig) (types.ContainerExecCreateResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
+	ContainerExecResize(ctx context.Context, options types.ResizeOptions) error
+	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
 	ContainerExport(ctx context.Context, containerID string) (io.ReadCloser, error)
-	ContainerInspect(containerID string) (types.ContainerJSON, error)
-	ContainerInspectWithRaw(containerID string, getSize bool) (types.ContainerJSON, []byte, error)
-	ContainerKill(containerID, signal string) error
-	ContainerList(options types.ContainerListOptions) ([]types.Container, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	ContainerInspectWithRaw(ctx context.Context, containerID string, getSize bool) (types.ContainerJSON, []byte, error)
+	ContainerKill(ctx context.Context, containerID, signal string) error
+	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerLogs(ctx context.Context, options types.ContainerLogsOptions) (io.ReadCloser, error)
-	ContainerPause(containerID string) error
-	ContainerRemove(options types.ContainerRemoveOptions) error
-	ContainerRename(containerID, newContainerName string) error
-	ContainerResize(options types.ResizeOptions) error
-	ContainerRestart(containerID string, timeout int) error
-	ContainerStatPath(containerID, path string) (types.ContainerPathStat, error)
+	ContainerPause(ctx context.Context, containerID string) error
+	ContainerRemove(ctx context.Context, options types.ContainerRemoveOptions) error
+	ContainerRename(ctx context.Context, containerID, newContainerName string) error
+	ContainerResize(ctx context.Context, options types.ResizeOptions) error
+	ContainerRestart(ctx context.Context, containerID string, timeout int) error
+	ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error)
-	ContainerStart(containerID string) error
-	ContainerStop(containerID string, timeout int) error
-	ContainerTop(containerID string, arguments []string) (types.ContainerProcessList, error)
-	ContainerUnpause(containerID string) error
-	ContainerUpdate(containerID string, updateConfig container.UpdateConfig) error
+	ContainerStart(ctx context.Context, containerID string) error
+	ContainerStop(ctx context.Context, containerID string, timeout int) error
+	ContainerTop(ctx context.Context, containerID string, arguments []string) (types.ContainerProcessList, error)
+	ContainerUnpause(ctx context.Context, containerID string) error
+	ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) error
 	ContainerWait(ctx context.Context, containerID string) (int, error)
 	CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, options types.CopyToContainerOptions) error
 	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
 	ImageBuild(ctx context.Context, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImageCreate(ctx context.Context, options types.ImageCreateOptions) (io.ReadCloser, error)
-	ImageHistory(imageID string) ([]types.ImageHistory, error)
+	ImageHistory(ctx context.Context, imageID string) ([]types.ImageHistory, error)
 	ImageImport(ctx context.Context, options types.ImageImportOptions) (io.ReadCloser, error)
-	ImageInspectWithRaw(imageID string, getSize bool) (types.ImageInspect, []byte, error)
-	ImageList(options types.ImageListOptions) ([]types.Image, error)
+	ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (types.ImageInspect, []byte, error)
+	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error)
 	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
 	ImagePull(ctx context.Context, options types.ImagePullOptions, privilegeFunc RequestPrivilegeFunc) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, options types.ImagePushOptions, privilegeFunc RequestPrivilegeFunc) (io.ReadCloser, error)
-	ImageRemove(options types.ImageRemoveOptions) ([]types.ImageDelete, error)
-	ImageSearch(options types.ImageSearchOptions, privilegeFunc RequestPrivilegeFunc) ([]registry.SearchResult, error)
+	ImageRemove(ctx context.Context, options types.ImageRemoveOptions) ([]types.ImageDelete, error)
+	ImageSearch(ctx context.Context, options types.ImageSearchOptions, privilegeFunc RequestPrivilegeFunc) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, imageIDs []string) (io.ReadCloser, error)
-	ImageTag(options types.ImageTagOptions) error
-	Info() (types.Info, error)
-	NetworkConnect(networkID, containerID string, config *network.EndpointSettings) error
-	NetworkCreate(options types.NetworkCreate) (types.NetworkCreateResponse, error)
-	NetworkDisconnect(networkID, containerID string, force bool) error
-	NetworkInspect(networkID string) (types.NetworkResource, error)
-	NetworkList(options types.NetworkListOptions) ([]types.NetworkResource, error)
-	NetworkRemove(networkID string) error
-	RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error)
-	ServerVersion() (types.Version, error)
-	VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error)
-	VolumeInspect(volumeID string) (types.Volume, error)
-	VolumeList(filter filters.Args) (types.VolumesListResponse, error)
-	VolumeRemove(volumeID string) error
+	ImageTag(ctx context.Context, options types.ImageTagOptions) error
+	Info(ctx context.Context) (types.Info, error)
+	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkCreate(ctx context.Context, options types.NetworkCreate) (types.NetworkCreateResponse, error)
+	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
+	NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error)
+	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
+	NetworkRemove(ctx context.Context, networkID string) error
+	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
+	ServerVersion(ctx context.Context) (types.Version, error)
+	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
+	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
+	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
+	VolumeRemove(ctx context.Context, volumeID string) error
 }
 
 // Ensure that Client always implements APIClient.

--- a/client/login.go
+++ b/client/login.go
@@ -6,12 +6,13 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // RegistryLogin authenticates the docker server with a given docker registry.
 // It returns UnauthorizerError when the authentication fails.
-func (cli *Client) RegistryLogin(auth types.AuthConfig) (types.AuthResponse, error) {
-	resp, err := cli.post("/auth", url.Values{}, auth, nil)
+func (cli *Client) RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error) {
+	resp, err := cli.post(ctx, "/auth", url.Values{}, auth, nil)
 
 	if resp != nil && resp.statusCode == http.StatusUnauthorized {
 		return types.AuthResponse{}, unauthorizedError{err}

--- a/client/network_connect.go
+++ b/client/network_connect.go
@@ -3,15 +3,16 @@ package client
 import (
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/network"
+	"golang.org/x/net/context"
 )
 
 // NetworkConnect connects a container to an existent network in the docker host.
-func (cli *Client) NetworkConnect(networkID, containerID string, config *network.EndpointSettings) error {
+func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error {
 	nc := types.NetworkConnect{
 		Container:      containerID,
 		EndpointConfig: config,
 	}
-	resp, err := cli.post("/networks/"+networkID+"/connect", nil, nc, nil)
+	resp, err := cli.post(ctx, "/networks/"+networkID+"/connect", nil, nc, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_create.go
+++ b/client/network_create.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // NetworkCreate creates a new network in the docker host.
-func (cli *Client) NetworkCreate(options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+func (cli *Client) NetworkCreate(ctx context.Context, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
 	var response types.NetworkCreateResponse
-	serverResp, err := cli.post("/networks/create", nil, options, nil)
+	serverResp, err := cli.post(ctx, "/networks/create", nil, options, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestNetworkCreateError(t *testing.T) {
@@ -17,7 +18,7 @@ func TestNetworkCreateError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NetworkCreate(types.NetworkCreate{})
+	_, err := client.NetworkCreate(context.Background(), types.NetworkCreate{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -50,7 +51,7 @@ func TestNetworkCreate(t *testing.T) {
 		}),
 	}
 
-	networkResponse, err := client.NetworkCreate(types.NetworkCreate{
+	networkResponse, err := client.NetworkCreate(context.Background(), types.NetworkCreate{
 		Name:           "mynetwork",
 		CheckDuplicate: true,
 		Driver:         "mydriver",

--- a/client/network_disconnect.go
+++ b/client/network_disconnect.go
@@ -2,12 +2,13 @@ package client
 
 import (
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
-func (cli *Client) NetworkDisconnect(networkID, containerID string, force bool) error {
+func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
 	nd := types.NetworkDisconnect{Container: containerID, Force: force}
-	resp, err := cli.post("/networks/"+networkID+"/disconnect", nil, nd, nil)
+	resp, err := cli.post(ctx, "/networks/"+networkID+"/disconnect", nil, nd, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
@@ -17,7 +18,7 @@ func TestNetworkDisconnectError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.NetworkDisconnect("network_id", "container_id", false)
+	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -56,7 +57,7 @@ func TestNetworkDisconnect(t *testing.T) {
 		}),
 	}
 
-	err := client.NetworkDisconnect("network_id", "container_id", true)
+	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(networkID string) (types.NetworkResource, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
 	var networkResource types.NetworkResource
-	resp, err := cli.get("/networks/"+networkID, nil, nil)
+	resp, err := cli.get(ctx, "/networks/"+networkID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return networkResource, networkNotFoundError{networkID}

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestNetworkInspectError(t *testing.T) {
@@ -17,7 +18,7 @@ func TestNetworkInspectError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NetworkInspect("nothing")
+	_, err := client.NetworkInspect(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -28,7 +29,7 @@ func TestNetworkInspectContainerNotFound(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, err := client.NetworkInspect("unknown")
+	_, err := client.NetworkInspect(context.Background(), "unknown")
 	if err == nil || !IsErrNetworkNotFound(err) {
 		t.Fatalf("expected a containerNotFound error, got %v", err)
 	}
@@ -58,7 +59,7 @@ func TestNetworkInspect(t *testing.T) {
 		}),
 	}
 
-	r, err := client.NetworkInspect("network_id")
+	r, err := client.NetworkInspect(context.Background(), "network_id")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(options types.NetworkListOptions) ([]types.NetworkResource, error) {
+func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToParam(options.Filters)
@@ -20,7 +21,7 @@ func (cli *Client) NetworkList(options types.NetworkListOptions) ([]types.Networ
 		query.Set("filters", filterJSON)
 	}
 	var networkResources []types.NetworkResource
-	resp, err := cli.get("/networks", query, nil)
+	resp, err := cli.get(ctx, "/networks", query, nil)
 	if err != nil {
 		return networkResources, err
 	}

--- a/client/network_remove.go
+++ b/client/network_remove.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // NetworkRemove removes an existent network from the docker host.
-func (cli *Client) NetworkRemove(networkID string) error {
-	resp, err := cli.delete("/networks/"+networkID, nil, nil)
+func (cli *Client) NetworkRemove(ctx context.Context, networkID string) error {
+	resp, err := cli.delete(ctx, "/networks/"+networkID, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/request.go
+++ b/client/request.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/client/transport/cancellable"
-
 	"golang.org/x/net/context"
 )
 
@@ -23,57 +22,41 @@ type serverResponse struct {
 }
 
 // head sends an http request to the docker API using the method HEAD.
-func (cli *Client) head(path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(context.Background(), "HEAD", path, query, nil, headers)
-}
-
-// get sends an http request to the docker API using the method GET.
-func (cli *Client) get(path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
-	return cli.getWithContext(context.Background(), path, query, headers)
+func (cli *Client) head(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "HEAD", path, query, nil, headers)
 }
 
 // getWithContext sends an http request to the docker API using the method GET with a specific go context.
-func (cli *Client) getWithContext(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+func (cli *Client) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
 	return cli.sendRequest(ctx, "GET", path, query, nil, headers)
 }
 
-// post sends an http request to the docker API using the method POST.
-func (cli *Client) post(path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	return cli.postWithContext(context.Background(), path, query, body, headers)
-}
-
 // postWithContext sends an http request to the docker API using the method POST with a specific go context.
-func (cli *Client) postWithContext(ctx context.Context, path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(ctx, "POST", path, query, body, headers)
+func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "POST", path, query, obj, headers)
 }
 
-// postRaw sends the raw input to the docker API using the method POST with a specific go context.
 func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
 	return cli.sendClientRequest(ctx, "POST", path, query, body, headers)
 }
 
 // put sends an http request to the docker API using the method PUT.
-func (cli *Client) put(path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(context.Background(), "PUT", path, query, body, headers)
+func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "PUT", path, query, obj, headers)
 }
 
-// putRaw sends the raw input to the docker API using the method PUT.
-func (cli *Client) putRaw(path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
-	return cli.putRawWithContext(context.Background(), path, query, body, headers)
-}
-
-// putRawWithContext sends the raw input to the docker API using the method PUT with a specific go context.
-func (cli *Client) putRawWithContext(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
+// put sends an http request to the docker API using the method PUT.
+func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {
 	return cli.sendClientRequest(ctx, "PUT", path, query, body, headers)
 }
 
 // delete sends an http request to the docker API using the method DELETE.
-func (cli *Client) delete(path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
-	return cli.sendRequest(context.Background(), "DELETE", path, query, nil, headers)
+func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (*serverResponse, error) {
+	return cli.sendRequest(ctx, "DELETE", path, query, nil, headers)
 }
 
-func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, body interface{}, headers map[string][]string) (*serverResponse, error) {
-	params, err := encodeData(body)
+func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
+	body, err := encodeData(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +68,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 		headers["Content-Type"] = []string{"application/json"}
 	}
 
-	return cli.sendClientRequest(ctx, method, path, query, params, headers)
+	return cli.sendClientRequest(ctx, method, path, query, body, headers)
 }
 
 func (cli *Client) sendClientRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers map[string][]string) (*serverResponse, error) {

--- a/client/version.go
+++ b/client/version.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // ServerVersion returns information of the docker client and server host.
-func (cli *Client) ServerVersion() (types.Version, error) {
-	resp, err := cli.get("/version", nil, nil)
+func (cli *Client) ServerVersion(ctx context.Context) (types.Version, error) {
+	resp, err := cli.get(ctx, "/version", nil, nil)
 	if err != nil {
 		return types.Version{}, err
 	}

--- a/client/volume_create.go
+++ b/client/volume_create.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // VolumeCreate creates a volume in the docker host.
-func (cli *Client) VolumeCreate(options types.VolumeCreateRequest) (types.Volume, error) {
+func (cli *Client) VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error) {
 	var volume types.Volume
-	resp, err := cli.post("/volumes/create", nil, options, nil)
+	resp, err := cli.post(ctx, "/volumes/create", nil, options, nil)
 	if err != nil {
 		return volume, err
 	}

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func TestVolumeCreateError(t *testing.T) {
@@ -17,7 +18,7 @@ func TestVolumeCreateError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.VolumeCreate(types.VolumeCreateRequest{})
+	_, err := client.VolumeCreate(context.Background(), types.VolumeCreateRequest{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -51,7 +52,7 @@ func TestVolumeCreate(t *testing.T) {
 		}),
 	}
 
-	volume, err := client.VolumeCreate(types.VolumeCreateRequest{
+	volume, err := client.VolumeCreate(context.Background(), types.VolumeCreateRequest{
 		Name:   "myvolume",
 		Driver: "mydriver",
 		DriverOpts: map[string]string{

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 // VolumeInspect returns the information about a specific volume in the docker host.
-func (cli *Client) VolumeInspect(volumeID string) (types.Volume, error) {
+func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error) {
 	var volume types.Volume
-	resp, err := cli.get("/volumes/"+volumeID, nil, nil)
+	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
 			return volume, volumeNotFoundError{volumeID}

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 // VolumeList returns the volumes configured in the docker host.
-func (cli *Client) VolumeList(filter filters.Args) (types.VolumesListResponse, error) {
+func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error) {
 	var volumes types.VolumesListResponse
 	query := url.Values{}
 
@@ -20,7 +21,7 @@ func (cli *Client) VolumeList(filter filters.Args) (types.VolumesListResponse, e
 		}
 		query.Set("filters", filterJSON)
 	}
-	resp, err := cli.get("/volumes", query, nil)
+	resp, err := cli.get(ctx, "/volumes", query, nil)
 	if err != nil {
 		return volumes, err
 	}

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/filters"
+	"golang.org/x/net/context"
 )
 
 func TestVolumeListError(t *testing.T) {
@@ -18,7 +19,7 @@ func TestVolumeListError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.VolumeList(filters.NewArgs())
+	_, err := client.VolumeList(context.Background(), filters.NewArgs())
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -85,7 +86,7 @@ func TestVolumeList(t *testing.T) {
 			}),
 		}
 
-		volumeResponse, err := client.VolumeList(listCase.filters)
+		volumeResponse, err := client.VolumeList(context.Background(), listCase.filters)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -1,8 +1,10 @@
 package client
 
+import "golang.org/x/net/context"
+
 // VolumeRemove removes a volume from the docker host.
-func (cli *Client) VolumeRemove(volumeID string) error {
-	resp, err := cli.delete("/volumes/"+volumeID, nil, nil)
+func (cli *Client) VolumeRemove(ctx context.Context, volumeID string) error {
+	resp, err := cli.delete(ctx, "/volumes/"+volumeID, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestVolumeRemoveError(t *testing.T) {
@@ -14,7 +16,7 @@ func TestVolumeRemoveError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.VolumeRemove("volume_id")
+	err := client.VolumeRemove(context.Background(), "volume_id")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -38,7 +40,7 @@ func TestVolumeRemove(t *testing.T) {
 		}),
 	}
 
-	err := client.VolumeRemove("volume_id")
+	err := client.VolumeRemove(context.Background(), "volume_id")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In general, `net/context.Context` should be the first argument to
methods that may be on a request call chain. While some API methods had
context, many did not, making support inconsistent. Applications that
require full plumbing of context, such as those that rely on
cancellation for resource cleanup, would be incompatible with
inconsistent plumbing. The change takes a first pass at adding context
through the entire API.

Close #139

Signed-off-by: Stephen J Day <stephen.day@docker.com>