### PR TITLE
types: stats: add pids.max to PidsStats

### DIFF
--- a/types/stats.go
+++ b/types/stats.go
@@ -91,6 +91,9 @@ type NetworkStats struct {
 type PidsStats struct {
 	// Current is the number of pids in the cgroup
 	Current uint64 `json:"current,omitempty"`
+	// Limit is the hard limit on the number of pids in the cgroup.
+	// A "Limit" of 0 means that there is no limit.
+	Limit uint64 `json:"limit,omitempty"`
 }
 
 // Stats is Ultimate struct aggregating all types of stats of one container


### PR DESCRIPTION
In order to allow nice usage statistics (in terms of percentages and
other such data), add the value of pids.max to the PidsStats struct
returned from the pids cgroup controller.

Signed-off-by: Aleksa Sarai <asarai@suse.de>