### PR TITLE
Add swarm node data

### DIFF
--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -67,3 +67,53 @@ func TestContainerInspect(t *testing.T) {
 		t.Fatalf("expected `name`, got %s", r.ID)
 	}
 }
+
+func TestContainerInspectNode(t *testing.T) {
+	client := &Client{
+		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			content, err := json.Marshal(types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    "container_id",
+					Image: "image",
+					Name:  "name",
+					Node: &types.ContainerNode{
+						ID:     "container_node_id",
+						Addr:   "container_node",
+						Labels: map[string]string{"foo": "bar"},
+					},
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+
+	r, err := client.ContainerInspect(context.Background(), "container_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != "container_id" {
+		t.Fatalf("expected `container_id`, got %s", r.ID)
+	}
+	if r.Image != "image" {
+		t.Fatalf("expected `image`, got %s", r.ID)
+	}
+	if r.Name != "name" {
+		t.Fatalf("expected `name`, got %s", r.ID)
+	}
+	if r.Node.ID != "container_node_id" {
+		t.Fatalf("expected `container_node_id`, got %s", r.Node.ID)
+	}
+	if r.Node.Addr != "container_node" {
+		t.Fatalf("expected `container_node`, got %s", r.Node.Addr)
+	}
+	foo, ok := r.Node.Labels["foo"]
+	if foo != "bar" || !ok {
+		t.Fatalf("expected `bar` for label `foo`")
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -281,6 +281,18 @@ type ContainerState struct {
 	FinishedAt string
 }
 
+// NodeData stores information about the node that a container
+// is running on.  It's only available in Docker Swarm
+type ContainerNode struct {
+	ID        string
+	IPAddress string `json:"IP"`
+	Addr      string
+	Name      string
+	Cpus      int
+	Memory    int
+	Labels    map[string]string
+}
+
 // ContainerJSONBase contains response of Remote API:
 // GET "/containers/{name:.*}/json"
 type ContainerJSONBase struct {
@@ -294,6 +306,7 @@ type ContainerJSONBase struct {
 	HostnamePath    string
 	HostsPath       string
 	LogPath         string
+	Node            *ContainerNode `json:",omitempty"`
 	Name            string
 	RestartCount    int
 	Driver          string


### PR DESCRIPTION
This change adds missing node information which is returned by
Docker Swarm.  Included are things like what node a container is
running on, the IP Address, any labels, etc.

Signed-off-by: Patrick Devine <patrick.devine@docker.com>