### PR TITLE
ImageImport should use postRaw instead of post.

### DIFF
--- a/client/image_import.go
+++ b/client/image_import.go
@@ -21,7 +21,7 @@ func (cli *Client) ImageImport(ctx context.Context, options types.ImageImportOpt
 		query.Add("changes", change)
 	}
 
-	resp, err := cli.post(ctx, "/images/create", query, options.Source, nil)
+	resp, err := cli.postRaw(ctx, "/images/create", query, options.Source, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Using post instead of postRaw makes client hang for ever. 

This is related to docker/docker#21219 🐳.

/cc @calavera @stevvooe @LK4D4 @cpuguy83 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>