### PR TITLE
Add go 1.6 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
   notifications:
     email: false
   go:
-    - 1.5
+    - 1.6
     - tip
   install: make deps
   script: make validate && make test


### PR DESCRIPTION
Go 1.6 has been released so "go tip" is pointing to 1.7 devel 🐯.

/cc @calavera @MHBauer 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>