### PR TITLE
Set TLS ServerName when the transport is created.

### DIFF
--- a/client/hijack.go
+++ b/client/hijack.go
@@ -46,7 +46,8 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 
-	conn, err := dial(cli.proto, cli.addr, cli.transport.TLSConfig())
+	tlsConfig := cli.transport.TLSConfig()
+	conn, err := dial(cli.proto, cli.addr, tlsConfig)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return types.HijackedResponse{}, fmt.Errorf("Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?")
@@ -123,21 +124,6 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 	if tcpConn, ok := rawConn.(*net.TCPConn); ok {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetKeepAlivePeriod(30 * time.Second)
-	}
-
-	colonPos := strings.LastIndex(addr, ":")
-	if colonPos == -1 {
-		colonPos = len(addr)
-	}
-	hostname := addr[:colonPos]
-
-	// If no ServerName is set, infer the ServerName
-	// from the hostname we're connecting to.
-	if config.ServerName == "" {
-		// Make a copy to avoid polluting argument or default.
-		c := *config
-		c.ServerName = hostname
-		config = &c
 	}
 
 	conn := tls.Client(rawConn, config)


### PR DESCRIPTION
Fixes issue in Go Devel:

```
go vet ./...

client/hijack.go:138: assignment copies lock value to c: crypto/tls.Config contains sync.Once contains sync.Mutex
```

Signed-off-by: David Calavera <david.calavera@gmail.com>