### PR TITLE
Label support for images, networks and volumes

### DIFF
--- a/client/image_build.go
+++ b/client/image_build.go
@@ -101,6 +101,11 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	}
 	query.Set("buildargs", string(buildArgsJSON))
 
+	labelsJSON, err := json.Marshal(options.Labels)
+	if err != nil {
+		return query, err
+	}
+	query.Set("labels", string(labelsJSON))
 	return query, nil
 }
 

--- a/types/client.go
+++ b/types/client.go
@@ -142,6 +142,7 @@ type ImageBuildOptions struct {
 	BuildArgs      map[string]string
 	AuthConfigs    map[string]AuthConfig
 	Context        io.Reader
+	Labels         map[string]string
 }
 
 // ImageBuildResponse holds information

--- a/types/types.go
+++ b/types/types.go
@@ -372,6 +372,7 @@ type Volume struct {
 	Driver     string                 // Driver is the Driver name used to create the volume
 	Mountpoint string                 // Mountpoint is the location on disk of the volume
 	Status     map[string]interface{} `json:",omitempty"` // Status provides low-level status information about the volume
+	Labels     map[string]string      // Labels is meta data specific to the volume
 }
 
 // VolumesListResponse contains the response for the remote API:
@@ -387,6 +388,7 @@ type VolumeCreateRequest struct {
 	Name       string            // Name is the requested name of the volume
 	Driver     string            // Driver is the name of the driver that should be used to create the volume
 	DriverOpts map[string]string // DriverOpts holds the driver specific options to use for when creating the volume.
+	Labels     map[string]string // Labels holds meta data specific to the volume being created.
 }
 
 // NetworkResource is the body of the "get network" http response message
@@ -400,6 +402,7 @@ type NetworkResource struct {
 	Internal   bool
 	Containers map[string]EndpointResource
 	Options    map[string]string
+	Labels     map[string]string
 }
 
 // EndpointResource contains network resources allocated and used for a container in a network
@@ -420,6 +423,7 @@ type NetworkCreate struct {
 	IPAM           network.IPAM
 	Internal       bool
 	Options        map[string]string
+	Labels         map[string]string
 }
 
 // NetworkCreateResponse is the response message sent by the server for network create call


### PR DESCRIPTION
This adds label support for images, networks and volumes on creation.

Refs: https://github.com/docker/docker/pull/21270