### PR TITLE
Add "SecurityOptions" in Info.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -243,6 +243,7 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
+	SecurityOptions    []string
 }
 
 // PluginsInfo is a temp struct holding Plugins name


### PR DESCRIPTION
This PR tries to add SecurityOptions field in Info so that security options such as apparmor, seccomp, or selinux could be displayed by `docker info`.

Detailed discussion could be found in:
https://github.com/docker/docker/issues/20909
https://github.com/docker/docker/pull/21172

cc @justincormack @calavera @thaJeztah 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>