### PR TITLE
add netmode for docker build

### DIFF
--- a/client/image_build.go
+++ b/client/image_build.go
@@ -79,6 +79,7 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	}
 
 	query.Set("cpusetcpus", options.CPUSetCPUs)
+	query.Set("netmode", options.NetMode)
 	query.Set("cpusetmems", options.CPUSetMems)
 	query.Set("cpushares", strconv.FormatInt(options.CPUShares, 10))
 	query.Set("cpuquota", strconv.FormatInt(options.CPUQuota, 10))

--- a/types/client.go
+++ b/types/client.go
@@ -136,6 +136,7 @@ type ImageBuildOptions struct {
 	Memory         int64
 	MemorySwap     int64
 	CgroupParent   string
+	NetMode        string
 	ShmSize        int64
 	Dockerfile     string
 	Ulimits        []*units.Ulimit


### PR DESCRIPTION
Create for PR [20987](https://github.com/docker/docker/pull/20987)
docker could't point a network mode when build a image ,in my case, we are unable to use bridge network mode because my company's restriction. So I add --net options for docker build command to use host network mode. 
In order to add this support , I have to change engine-api , So I create this PR.


Signed-off-by: sandyskies <chenmingjie0828@163.com>