### PR TITLE
fix the incorrect demo code, the context argument should be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
 )
 
 func main() {
@@ -32,7 +34,7 @@ func main() {
 	}
 
 	options := types.ContainerListOptions{All: true}
-	containers, err := cli.ContainerList(options)
+	containers, err := cli.ContainerList(context.Background(), options)
 	if err != nil {
 		panic(err)
 	}

--- a/doc.go
+++ b/doc.go
@@ -15,7 +15,7 @@ Other programs, like Docker Machine, can set the default Docker engine environme
 All request arguments are defined as typed structures in the types package. For instance, this is how to get all containers running in the host:
 
 	options := types.ContainerListOptions{All: true}
-	containers, err := cli.ContainerList(options)
+	containers, err := cli.ContainerList(context.Background(), options)
 
 */
 package engineapi


### PR DESCRIPTION
fix https://github.com/docker/engine-api/issues/163 by passing the context argument as the first argument.