### PR TITLE
Fix Windows storage qos hostconfig names

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -236,11 +236,10 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount    int64  `json:"CpuCount"`   // CPU count
-	CPUPercent  int64  `json:"CpuPercent"` // CPU percent
-	BlkioIOps   uint64 // Maximum IOps for the container system drive
-	BlkioBps    uint64 // Maximum Bytes per second for the container system drive
-	SandboxSize uint64 // System drive will be expanded to at least this size (in bytes)
+	CPUCount     int64  `json:"CpuCount"`   // CPU count
+	CPUPercent   int64  `json:"CpuPercent"` // CPU percent
+	MaximumIOps  uint64 // Maximum IOps for the container system drive
+	MaximumIOBps uint64 // Maximum IO in bytes per second for the container system drive
 }
 
 // UpdateConfig holds the mutable attributes of a Container.


### PR DESCRIPTION
These host config parameters are not currently used. This PR names them more correctly, as they are not exactly Block IO.

It also removes the SandboxSize option which was unused, as it fits better in the recently added StorageOpts[].

Signed-off-by: Darren Stahl <darst@microsoft.com>