### PR TITLE
Make sure the request path is properly encoded.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@
     email: false
   go:
     - 1.6
-    - tip
   install: make deps
   script: make validate && make test

--- a/client/client.go
+++ b/client/client.go
@@ -97,10 +97,14 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	} else {
 		apiPath = fmt.Sprintf("%s%s", cli.basePath, p)
 	}
-	if len(query) > 0 {
-		apiPath += "?" + query.Encode()
+
+	u := &url.URL{
+		Path: apiPath,
 	}
-	return apiPath
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	return u.String()
 }
 
 // ClientVersion returns the version string associated with this

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -21,6 +21,7 @@ func TestGetAPIPath(t *testing.T) {
 		{"v1.22", "/containers/json", nil, "/v1.22/containers/json"},
 		{"v1.22", "/containers/json", url.Values{}, "/v1.22/containers/json"},
 		{"v1.22", "/containers/json", url.Values{"s": []string{"c"}}, "/v1.22/containers/json?s=c"},
+		{"v1.22", "/networks/kiwl$%^", nil, "/v1.22/networks/kiwl$%25%5E"},
 	}
 
 	for _, cs := range cases {


### PR DESCRIPTION
Some endpoints can have special characters in the name, this ensures that we escape them properly.
See https://github.com/docker/docker/pull/21421.

Signed-off-by: David Calavera <david.calavera@gmail.com>