### PR TITLE
Fix for Swarm issue #2027

### DIFF
--- a/client/transport/transport.go
+++ b/client/transport/transport.go
@@ -35,10 +35,10 @@ func NewTransportWithHTTP(proto, addr string, client *http.Client) (Client, erro
 		}
 	}
 
-	if transport.TLSClientConfig != nil && transport.TLSClientConfig.ServerName == "" {
-		transport.TLSClientConfig.ServerName = hostname(addr)
-	}
-
+	// if transport.TLSClientConfig != nil && transport.TLSClientConfig.ServerName == "" {
+	// 	transport.TLSClientConfig.ServerName = hostname(addr)
+	// }
+	//
 	return &apiTransport{
 		Client:    client,
 		tlsInfo:   &tlsInfo{transport.TLSClientConfig},


### PR DESCRIPTION
`NewEngine()` call contains pointer to `http.Client` structure, which contains
pointer to `http.Transport`, which in turn contains `TLSClientConfig *tls.Config`

That way, its very possible that the same TLS config can be used to communicate
with different Docker engines. And explicitly setting `ServerName` really hurts.

And we can see such situation with current master Swarm build (https://github.com/docker/swarm/issues/2027)

Signed-off-by: Eugene Chupriyanov <e.chuprianov@cpm.ru>