### PR TITLE
Allowing slice container filters for older daemons

### DIFF
--- a/client/container_list.go
+++ b/client/container_list.go
@@ -35,7 +35,8 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 	}
 
 	if options.Filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filter)
+
 		if err != nil {
 			return nil, err
 		}

--- a/types/filters/parse.go
+++ b/types/filters/parse.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -62,6 +63,26 @@ func ToParam(a Args) (string, error) {
 	}
 
 	buf, err := json.Marshal(a.fields)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func ToParamWithVersion(version string, a Args) (string, error) {
+	// this way we don't URL encode {}, just empty space
+	if a.Len() == 0 {
+		return "", nil
+	}
+
+	// for daemons older than v1.10, filter must be of the form map[string][]string
+	buf := []byte{}
+	err := errors.New("")
+	if version != "" && compareTo(version, "1.22") == -1 {
+		buf, err = json.Marshal(convertArgsToSlice(a.fields))
+	} else {
+		buf, err = json.Marshal(a.fields)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -254,4 +275,49 @@ func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
 		m[k] = values
 	}
 	return m
+}
+
+func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
+	m := map[string][]string{}
+	for k, v := range f {
+		values := []string{}
+		for kk, _ := range v {
+			if v[kk] {
+				values = append(values, kk)
+			}
+		}
+		m[k] = values
+	}
+	return m
+}
+
+// compareTo compares two version strings
+// returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise
+func compareTo(v1, v2 string) int {
+	var (
+		currTab  = strings.Split(v1, ".")
+		otherTab = strings.Split(v2, ".")
+	)
+
+	max := len(currTab)
+	if len(otherTab) > max {
+		max = len(otherTab)
+	}
+	for i := 0; i < max; i++ {
+		var currInt, otherInt int
+
+		if len(currTab) > i {
+			currInt, _ = strconv.Atoi(currTab[i])
+		}
+		if len(otherTab) > i {
+			otherInt, _ = strconv.Atoi(otherTab[i])
+		}
+		if currInt > otherInt {
+			return 1
+		}
+		if otherInt > currInt {
+			return -1
+		}
+	}
+	return 0
 }

--- a/types/filters/parse_test.go
+++ b/types/filters/parse_test.go
@@ -57,6 +57,31 @@ func TestToParam(t *testing.T) {
 	}
 }
 
+func TestToParamWithVersion(t *testing.T) {
+	fields := map[string]map[string]bool{
+		"created":    {"today": true},
+		"image.name": {"ubuntu*": true, "*untu": true},
+	}
+	a := Args{fields: fields}
+
+	str1, err := ToParamWithVersion("1.21", a)
+	if err != nil {
+		t.Errorf("failed to marshal the filters with version < 1.22: %s", err)
+	}
+	str2, err := ToParamWithVersion("1.22", a)
+	if err != nil {
+		t.Errorf("failed to marshal the filters with version >= 1.22: %s", err)
+	}
+	if str1 != `{"created":["today"],"image.name":["*untu","ubuntu*"]}` &&
+		str1 != `{"created":["today"],"image.name":["ubuntu*","*untu"]}` {
+		t.Errorf("incorrectly marshaled the filters: %s", str1)
+	}
+	if str2 != `{"created":{"today":true},"image.name":{"*untu":true,"ubuntu*":true}}` &&
+		str2 != `{"created":{"today":true},"image.name":{"ubuntu*":true,"*untu":true}}` {
+		t.Errorf("incorrectly marshaled the filters: %s", str2)
+	}
+}
+
 func TestFromParam(t *testing.T) {
 	invalids := []string{
 		"anything",


### PR DESCRIPTION
This PR adds support for passing container filters to daemons older than 1.10

cc @calavera @dongluochen 

Fixes #171 

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>