### PR TITLE
Add checkpoint/restore interface to the engine API.

### DIFF
--- a/client/container_checkpoint.go
+++ b/client/container_checkpoint.go
@@ -9,15 +9,16 @@ import (
 )
 
 // ContainerCheckpoint checkpoints a running container
-func (cli *Client) ContainerCheckpoint(ctx context.Context, containerID string, exit bool) (types.ContainerCheckpointResponse, error) {
+func (cli *Client) ContainerCheckpoint(ctx context.Context, options types.ContainerCheckpointOptions) (types.ContainerCheckpointResponse, error) {
 	query := url.Values{}
+	query.Set("id", options.CheckpointID)
 	query.Set("exit", "0")
-	if exit {
+	if options.Exit {
 		query.Set("exit", "1")
 	}
 
 	var response types.ContainerCheckpointResponse
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/checkpoint", query, nil, nil)
+	resp, err := cli.post(ctx, "/containers/"+options.ContainerID+"/checkpoint", query, nil, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_checkpoint.go
+++ b/client/container_checkpoint.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// ContainerCheckpoint checkpoints a running container
+func (cli *Client) ContainerCheckpoint(ctx context.Context, containerID string, exit bool) (types.ContainerCheckpointResponse, error) {
+	query := url.Values{}
+	query.Set("exit", "0")
+	if exit {
+		query.Set("exit", "1")
+	}
+
+	var response types.ContainerCheckpointResponse
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/checkpoint", query, nil, nil)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
+	return response, err
+}

--- a/client/container_checkpoint_test.go
+++ b/client/container_checkpoint_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+func TestContainerCheckpointError(t *testing.T) {
+	client := &Client{
+		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
+	}
+	_, err := client.ContainerCheckpoint(context.Background(), "nothing", true)
+
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerCheckpoint(t *testing.T) {
+	expectedContainerID := "container_id"
+	expectedCheckpointID := "checkpoint_id"
+
+	client := &Client{
+		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			exit := req.URL.Query().Get("exit")
+			if exit != "1" {
+				return nil, fmt.Errorf("exit not set in URL query properly. Expected '1', got %s", exit)
+			}
+			b, err := json.Marshal(types.ContainerCheckpointResponse{
+				ID: expectedCheckpointID,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	r, err := client.ContainerCheckpoint(context.Background(), expectedContainerID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != expectedCheckpointID {
+		t.Fatalf("expected `checkpoint_id`, got %s", r.ID)
+	}
+}

--- a/client/container_restore.go
+++ b/client/container_restore.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+// ContainerCheckpoint checkpoints a running container
+func (cli *Client) ContainerRestore(ctx context.Context, containerID string, checkpointID string) error {
+	query := url.Values{}
+	query.Set("id", checkpointID)
+
+	_, err := cli.post(ctx, "/containers/"+containerID+"/restore", query, nil, nil)
+
+	return err
+}

--- a/client/container_restore.go
+++ b/client/container_restore.go
@@ -3,15 +3,16 @@ package client
 import (
 	"net/url"
 
+	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
-// ContainerCheckpoint checkpoints a running container
-func (cli *Client) ContainerRestore(ctx context.Context, containerID string, checkpointID string) error {
+// ContainerRestore restores a running container
+func (cli *Client) ContainerRestore(ctx context.Context, options types.ContainerRestoreOptions) error {
 	query := url.Values{}
-	query.Set("id", checkpointID)
+	query.Set("id", options.CheckpointID)
 
-	_, err := cli.post(ctx, "/containers/"+containerID+"/restore", query, nil, nil)
+	_, err := cli.post(ctx, "/containers/"+options.ContainerID+"/restore", query, nil, nil)
 
 	return err
 }

--- a/client/container_restore_test.go
+++ b/client/container_restore_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
@@ -14,7 +15,10 @@ func TestContainerRestoreError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerRestore(context.Background(), "nothing", "nothing")
+	err := client.ContainerRestore(context.Background(), types.ContainerRestoreOptions{
+		ContainerID:  "nothing",
+		CheckpointID: "nothing",
+	})
 
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
@@ -38,7 +42,11 @@ func TestContainerRestore(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerRestore(context.Background(), containerID, checkpointID)
+	err := client.ContainerRestore(context.Background(), types.ContainerRestoreOptions{
+		ContainerID:  containerID,
+		CheckpointID: checkpointID,
+	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_restore_test.go
+++ b/client/container_restore_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestContainerRestoreError(t *testing.T) {
+	client := &Client{
+		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
+	}
+	err := client.ContainerRestore(context.Background(), "nothing", "nothing")
+
+	if err == nil || err.Error() != "Error response from daemon: Server error" {
+		t.Fatalf("expected a Server Error, got %v", err)
+	}
+}
+
+func TestContainerRestore(t *testing.T) {
+	containerID := "container_id"
+	checkpointID := "checkpoint_id"
+
+	client := &Client{
+		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			id := req.URL.Query().Get("id")
+			if id != checkpointID {
+				return nil, fmt.Errorf("id not set in URL query properly. Expected 'checkpoint_id', got %s", id)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+			}, nil
+		}),
+	}
+
+	err := client.ContainerRestore(context.Background(), containerID, checkpointID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -16,6 +16,7 @@ import (
 type APIClient interface {
 	ClientVersion() string
 	ContainerAttach(ctx context.Context, options types.ContainerAttachOptions) (types.HijackedResponse, error)
+	ContainerCheckpoint(ctx context.Context, containerID string, exit bool) (types.ContainerCheckpointResponse, error)
 	ContainerCommit(ctx context.Context, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
 	ContainerDiff(ctx context.Context, ontainerID string) ([]types.ContainerChange, error)
@@ -35,6 +36,7 @@ type APIClient interface {
 	ContainerRename(ctx context.Context, containerID, newContainerName string) error
 	ContainerResize(ctx context.Context, options types.ResizeOptions) error
 	ContainerRestart(ctx context.Context, containerID string, timeout int) error
+	ContainerRestore(ctx context.Context, containerID string, checkpointID string) error
 	ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error)
 	ContainerStart(ctx context.Context, containerID string) error

--- a/client/interface.go
+++ b/client/interface.go
@@ -16,7 +16,7 @@ import (
 type APIClient interface {
 	ClientVersion() string
 	ContainerAttach(ctx context.Context, options types.ContainerAttachOptions) (types.HijackedResponse, error)
-	ContainerCheckpoint(ctx context.Context, containerID string, exit bool) (types.ContainerCheckpointResponse, error)
+	ContainerCheckpoint(ctx context.Context, options types.ContainerCheckpointOptions) (types.ContainerCheckpointResponse, error)
 	ContainerCommit(ctx context.Context, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
 	ContainerDiff(ctx context.Context, ontainerID string) ([]types.ContainerChange, error)
@@ -36,7 +36,7 @@ type APIClient interface {
 	ContainerRename(ctx context.Context, containerID, newContainerName string) error
 	ContainerResize(ctx context.Context, options types.ResizeOptions) error
 	ContainerRestart(ctx context.Context, containerID string, timeout int) error
-	ContainerRestore(ctx context.Context, containerID string, checkpointID string) error
+	ContainerRestore(ctx context.Context, options types.ContainerRestoreOptions) error
 	ContainerStatPath(ctx context.Context, containerID, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error)
 	ContainerStart(ctx context.Context, containerID string) error

--- a/types/client.go
+++ b/types/client.go
@@ -20,6 +20,13 @@ type ContainerAttachOptions struct {
 	DetachKeys  string
 }
 
+// ContainerCheckpointOptions holds parameters to checkpoint a container.
+type ContainerCheckpointOptions struct {
+	ContainerID  string
+	CheckpointID string
+	Exit         bool
+}
+
 // ContainerCommitOptions holds parameters to commit changes into a container.
 type ContainerCommitOptions struct {
 	ContainerID    string
@@ -69,6 +76,12 @@ type ContainerRemoveOptions struct {
 	RemoveVolumes bool
 	RemoveLinks   bool
 	Force         bool
+}
+
+// ContainerRestoreOptions holds parameters to restore a container.
+type ContainerRestoreOptions struct {
+	ContainerID  string
+	CheckpointID string
 }
 
 // CopyToContainerOptions holds information

--- a/types/types.go
+++ b/types/types.go
@@ -52,6 +52,12 @@ type ContainerWaitResponse struct {
 	StatusCode int `json:"StatusCode"`
 }
 
+// ContainerCheckpointResponse contains response of Remote API:
+// POST "/containers/{name:.*}/checkpoint"
+type ContainerCheckpointResponse struct {
+	ID string `json:"Id"`
+}
+
 // ContainerCommitResponse contains response of Remote API:
 // POST "/commit?container="+containerID
 type ContainerCommitResponse struct {


### PR DESCRIPTION
An initial attempt at introducing an interface for checkpoint/restore to the engine API. Currently, the only checkpoint option is "exit", and the only restore option is the checkpoint id to restore. I'd love to hear from @crosbymichael about the containerd level options and what we'd like to see in Docker.

Containerd currently doesn't seem to support a specific path for checkpoint images, which would be really helpful for my own use case. The other options currently in containerd seem potentially ok to leave out.