### PR TITLE
Revert "Set the TLS connection ServerName when the transport is created."

### DIFF
--- a/client/hijack.go
+++ b/client/hijack.go
@@ -46,8 +46,7 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 
-	tlsConfig := cli.transport.TLSConfig()
-	conn, err := dial(cli.proto, cli.addr, tlsConfig)
+	conn, err := dial(cli.proto, cli.addr, cli.transport.TLSConfig())
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return types.HijackedResponse{}, fmt.Errorf("Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?")
@@ -124,6 +123,21 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 	if tcpConn, ok := rawConn.(*net.TCPConn); ok {
 		tcpConn.SetKeepAlive(true)
 		tcpConn.SetKeepAlivePeriod(30 * time.Second)
+	}
+
+	colonPos := strings.LastIndex(addr, ":")
+	if colonPos == -1 {
+		colonPos = len(addr)
+	}
+	hostname := addr[:colonPos]
+
+	// If no ServerName is set, infer the ServerName
+	// from the hostname we're connecting to.
+	if config.ServerName == "" {
+		// Make a copy to avoid polluting argument or default.
+		c := *config
+		c.ServerName = hostname
+		config = &c
 	}
 
 	conn := tls.Client(rawConn, config)

--- a/client/transport/transport.go
+++ b/client/transport/transport.go
@@ -4,7 +4,6 @@ package transport
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/docker/go-connections/sockets"
 )
@@ -35,10 +34,6 @@ func NewTransportWithHTTP(proto, addr string, client *http.Client) (Client, erro
 		}
 	}
 
-	if transport.TLSClientConfig != nil && transport.TLSClientConfig.ServerName == "" {
-		transport.TLSClientConfig.ServerName = hostname(addr)
-	}
-
 	return &apiTransport{
 		Client:    client,
 		tlsInfo:   &tlsInfo{transport.TLSClientConfig},
@@ -57,14 +52,6 @@ func defaultTransport(proto, addr string) *http.Transport {
 	tr := new(http.Transport)
 	sockets.ConfigureTransport(tr, proto, addr)
 	return tr
-}
-
-func hostname(addr string) string {
-	colonPos := strings.LastIndex(addr, ":")
-	if colonPos == -1 {
-		return addr
-	}
-	return addr[:colonPos]
 }
 
 var _ Client = &apiTransport{}


### PR DESCRIPTION
This reverts commit 9eec4dc67b13ace4c3c34496089122b9f1f7c28e.

This will be tagged as v0.3.2 and vendored in docker/docker.

Signed-off-by: David Calavera <david.calavera@gmail.com>
(cherry picked from commit b1e8fe822ff5334a9ff46ccf3a7efe60cfabe057)