### PR TITLE
rename IO maximums to better match the existing naming

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -236,10 +236,10 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount     int64  `json:"CpuCount"`   // CPU count
-	CPUPercent   int64  `json:"CpuPercent"` // CPU percent
-	MaximumIOps  uint64 // Maximum IOps for the container system drive
-	MaximumIOBps uint64 // Maximum IO in bytes per second for the container system drive
+	CPUCount           int64  `json:"CpuCount"`   // CPU count
+	CPUPercent         int64  `json:"CpuPercent"` // CPU percent
+	IOMaximumIOps      uint64 // Maximum IOps for the container system drive
+	IOMaximumBandwidth uint64 // Maximum IO in bytes per second for the container system drive
 }
 
 // UpdateConfig holds the mutable attributes of a Container.


### PR DESCRIPTION
One more name change on the IO Maximum settings. This aligns better with the existing device name followed by setting name.

Signed-off-by: Darren Stahl <darst@microsoft.com>