### PR TITLE
Throw client.Do(req) error in postHijacked

### DIFF
--- a/client/hijack.go
+++ b/client/hijack.go
@@ -68,11 +68,11 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	defer clientconn.Close()
 
 	// Server hijacks the connection, error 'connection closed' expected
-	clientconn.Do(req)
+	_, err = clientconn.Do(req)
 
 	rwc, br := clientconn.Hijack()
 
-	return types.HijackedResponse{Conn: rwc, Reader: br}, nil
+	return types.HijackedResponse{Conn: rwc, Reader: br}, err
 }
 
 func tlsDial(network, addr string, config *tls.Config) (net.Conn, error) {


### PR DESCRIPTION
Related docker PR: https://github.com/docker/docker/pull/21092

Sometime when client issues an http request via clientconn.Do(req),
server can send an error through hijacked http connection and close this
connection afterwards. We need to throw this error(httputil.ErrPersistEOF)
out, to let client know the connection is closed, so client can choose
to abort after reading detailed error message from hijacked connection.

Also client can ignore other kinds of errors, so it won't bring any problem.
And it will make more sense to not swallow the error.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>