### PR TITLE
Don't claim to have json payload when it is blank

### DIFF
--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -22,6 +24,13 @@ func TestContainerStartError(t *testing.T) {
 func TestContainerStart(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			// we're not expecting any payload, but if one is supplied, check it is valid.
+			if req.Header.Get("Content-Type") == "application/json" {
+				var startConfig interface{}
+				if err := json.NewDecoder(req.Body).Decode(&startConfig); err != nil {
+					return nil, fmt.Errorf("Unable to parse json: %s", err)
+				}
+			}
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),

--- a/client/request.go
+++ b/client/request.go
@@ -61,7 +61,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 		return nil, err
 	}
 
-	if body != nil {
+	if obj != nil {
 		if headers == nil {
 			headers = make(map[string][]string)
 		}

--- a/client/request.go
+++ b/client/request.go
@@ -56,12 +56,14 @@ func (cli *Client) delete(ctx context.Context, path string, query url.Values, he
 }
 
 func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, obj interface{}, headers map[string][]string) (*serverResponse, error) {
-	body, err := encodeData(obj)
-	if err != nil {
-		return nil, err
-	}
+	var body io.Reader
 
 	if obj != nil {
+		var err error
+		body, err = encodeData(obj)
+		if err != nil {
+			return nil, err
+		}
 		if headers == nil {
 			headers = make(map[string][]string)
 		}


### PR DESCRIPTION
https://github.com/docker/engine-api/commit/002fcc738c1ef307200e0ac1cb86a3306d9ffe8a#diff-ac3eb5494dc3178ea5947441c086942bR59 had the unfortunate effect of changing the behaviour of the second if-statement: it is meant to skip setting the Content-Type if the body is actually empty.

An empty string is not valid JSON so some recipients of the data may object, e.g. as found in https://github.com/weaveworks/weave/issues/2109