### PR TITLE
Fixes lint in `validate` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all deps test validate
+.PHONY: all deps test validate lint
 
 all: deps test validate
 
@@ -9,7 +9,13 @@ deps:
 test:
 	go test -race -cover ./...
 
-validate:
+validate: lint
 	go vet ./...
-	test -z "$(golint ./... | tee /dev/stderr)"
 	test -z "$(gofmt -s -l . | tee /dev/stderr)"
+
+lint:
+	out="$$(golint ./...)"; \
+	if [ -n "$$(golint ./...)" ]; then \
+		echo "$$out"; \
+		exit 1; \
+	fi

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -14,17 +14,17 @@ type mockClient struct {
 }
 
 // TLSConfig returns the TLS configuration.
-func (t *mockClient) TLSConfig() *tls.Config {
+func (m *mockClient) TLSConfig() *tls.Config {
 	return &tls.Config{}
 }
 
 // Scheme returns protocol scheme to use.
-func (t *mockClient) Scheme() string {
+func (m *mockClient) Scheme() string {
 	return "http"
 }
 
 // Secure returns true if there is a TLS configuration.
-func (t *mockClient) Secure() bool {
+func (m *mockClient) Secure() bool {
 	return false
 }
 

--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -92,11 +92,13 @@ func (n UsernsMode) Valid() bool {
 // CgroupSpec represents the cgroup to use for the container.
 type CgroupSpec string
 
+// IsContainer indicates whether the container is using another container cgroup
 func (c CgroupSpec) IsContainer() bool {
 	parts := strings.SplitN(string(c), ":", 2)
 	return len(parts) > 1 && parts[0] == "container"
 }
 
+// Valid indicates whether the cgroup spec is valid.
 func (c CgroupSpec) Valid() bool {
 	return c.IsContainer() || c == ""
 }

--- a/types/types.go
+++ b/types/types.go
@@ -290,7 +290,7 @@ type ContainerState struct {
 	FinishedAt string
 }
 
-// NodeData stores information about the node that a container
+// ContainerNode stores information about the node that a container
 // is running on.  It's only available in Docker Swarm
 type ContainerNode struct {
 	ID        string


### PR DESCRIPTION
For some reason, the `golint` check in `make validate` does nothing, and thus, we missed some lint warnings 🐙.

This add a `lint` target and make the `validate` target depends on and make it pass.

/cc @calavera @MHBauer @mrunalp (for the comment on `CgroupSpec`

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>