### PR TITLE
Set fake host header for local communication.

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -83,6 +83,11 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 	}
 
 	req, err := cli.newRequest(method, path, query, body, headers)
+	if cli.proto == "unix" || cli.proto == "npipe" {
+		// For local communications, it doesn't matter what the host is. We just
+		// need a valid and meaningful host name. (See #189)
+		req.Host = "docker"
+	}
 	req.URL.Host = cli.addr
 	req.URL.Scheme = cli.transport.Scheme()
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+// TestSetHostHeader should set fake host for local communications, set real host
+// for normal communications.
+func TestSetHostHeader(t *testing.T) {
+	testURL := "/test"
+	testCases := []struct {
+		host            string
+		expectedHost    string
+		expectedURLHost string
+	}{
+		{
+			"unix:///var/run/docker.sock",
+			"docker",
+			"/var/run/docker.sock",
+		},
+		{
+			"npipe:////./pipe/docker_engine",
+			"docker",
+			"//./pipe/docker_engine",
+		},
+		{
+			"tcp://0.0.0.0:4243",
+			"",
+			"0.0.0.0:4243",
+		},
+		{
+			"tcp://localhost:4243",
+			"",
+			"localhost:4243",
+		},
+	}
+
+	for c, test := range testCases {
+		proto, addr, basePath, err := ParseHost(test.host)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		client := &Client{
+			transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+				if !strings.HasPrefix(req.URL.Path, testURL) {
+					return nil, fmt.Errorf("Test Case #%d: Expected URL %q, got %q", c, testURL, req.URL)
+				}
+				if req.Host != test.expectedHost {
+					return nil, fmt.Errorf("Test Case #%d: Expected host %q, got %q", c, test.expectedHost, req.Host)
+				}
+				if req.URL.Host != test.expectedURLHost {
+					return nil, fmt.Errorf("Test Case #%d: Expected URL host %q, got %q", c, test.expectedURLHost, req.URL.Host)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader(([]byte("")))),
+				}, nil
+			}),
+			proto:    proto,
+			addr:     addr,
+			basePath: basePath,
+		}
+
+		_, err = client.sendRequest(context.Background(), "GET", testURL, nil, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
For issue #189.

In this PR, I set `URL.Host` to a fake address "docker.sock" to solve #189.

Hope this could be in, thanks! :)

@duglin @vdemeester