### PR TITLE
Move Docker version comparisons to the types package.

### DIFF
--- a/types/filters/parse.go
+++ b/types/filters/parse.go
@@ -7,8 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
+
+	"github.com/docker/engine-api/types/versions"
 )
 
 // Args stores filter arguments as map key:{map key: bool}.
@@ -80,7 +81,7 @@ func ToParamWithVersion(version string, a Args) (string, error) {
 	// for daemons older than v1.10, filter must be of the form map[string][]string
 	buf := []byte{}
 	err := errors.New("")
-	if version != "" && compareTo(version, "1.22") == -1 {
+	if version != "" && versions.LessThan(version, "1.22") {
 		buf, err = json.Marshal(convertArgsToSlice(a.fields))
 	} else {
 		buf, err = json.Marshal(a.fields)
@@ -291,35 +292,4 @@ func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
 		m[k] = values
 	}
 	return m
-}
-
-// compareTo compares two version strings
-// returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise
-func compareTo(v1, v2 string) int {
-	var (
-		currTab  = strings.Split(v1, ".")
-		otherTab = strings.Split(v2, ".")
-	)
-
-	max := len(currTab)
-	if len(otherTab) > max {
-		max = len(otherTab)
-	}
-	for i := 0; i < max; i++ {
-		var currInt, otherInt int
-
-		if len(currTab) > i {
-			currInt, _ = strconv.Atoi(currTab[i])
-		}
-		if len(otherTab) > i {
-			otherInt, _ = strconv.Atoi(otherTab[i])
-		}
-		if currInt > otherInt {
-			return 1
-		}
-		if otherInt > currInt {
-			return -1
-		}
-	}
-	return 0
 }

--- a/types/versions/compare.go
+++ b/types/versions/compare.go
@@ -1,0 +1,62 @@
+package versions
+
+import (
+	"strconv"
+	"strings"
+)
+
+// compare compares two version strings
+// returns -1 if v1 < v2, 1 if v1 > v2, 0 otherwise.
+func compare(v1, v2 string) int {
+	var (
+		currTab  = strings.Split(v1, ".")
+		otherTab = strings.Split(v2, ".")
+	)
+
+	max := len(currTab)
+	if len(otherTab) > max {
+		max = len(otherTab)
+	}
+	for i := 0; i < max; i++ {
+		var currInt, otherInt int
+
+		if len(currTab) > i {
+			currInt, _ = strconv.Atoi(currTab[i])
+		}
+		if len(otherTab) > i {
+			otherInt, _ = strconv.Atoi(otherTab[i])
+		}
+		if currInt > otherInt {
+			return 1
+		}
+		if otherInt > currInt {
+			return -1
+		}
+	}
+	return 0
+}
+
+// LessThan checks if a version is less than another
+func LessThan(v, other string) bool {
+	return compare(v, other) == -1
+}
+
+// LessThanOrEqualTo checks if a version is less than or equal to another
+func LessThanOrEqualTo(v, other string) bool {
+	return compare(v, other) <= 0
+}
+
+// GreaterThan checks if a version is greater than another
+func GreaterThan(v, other string) bool {
+	return compare(v, other) == 1
+}
+
+// GreaterThanOrEqualTo checks if a version is greater than or equal to another
+func GreaterThanOrEqualTo(v, other string) bool {
+	return compare(v, other) >= 0
+}
+
+// Equal checks if a version is equal to another
+func Equal(v, other string) bool {
+	return compare(v, other) == 0
+}

--- a/types/versions/compare_test.go
+++ b/types/versions/compare_test.go
@@ -1,0 +1,26 @@
+package versions
+
+import (
+	"testing"
+)
+
+func assertVersion(t *testing.T, a, b string, result int) {
+	if r := compare(a, b); r != result {
+		t.Fatalf("Unexpected version comparison result. Found %d, expected %d", r, result)
+	}
+}
+
+func TestCompareVersion(t *testing.T) {
+	assertVersion(t, "1.12", "1.12", 0)
+	assertVersion(t, "1.0.0", "1", 0)
+	assertVersion(t, "1", "1.0.0", 0)
+	assertVersion(t, "1.05.00.0156", "1.0.221.9289", 1)
+	assertVersion(t, "1", "1.0.1", -1)
+	assertVersion(t, "1.0.1", "1", 1)
+	assertVersion(t, "1.0.1", "1.0.2", -1)
+	assertVersion(t, "1.0.2", "1.0.3", -1)
+	assertVersion(t, "1.0.3", "1.1", -1)
+	assertVersion(t, "1.1", "1.1.1", -1)
+	assertVersion(t, "1.1.1", "1.1.2", -1)
+	assertVersion(t, "1.1.2", "1.2", -1)
+}


### PR DESCRIPTION
Most of the comparisons are done at the API level.
In the long term, it makes more sense to have these functions
in this package, so people can reuse them implementing other clients.

This change removes the custom Version type. The custom type doesn't
provide any extra value since you can wrap any string in it an the
comparisons can easily be done with plain strings.

I'll proceed to make the necessary changes in docker/docker if this gets merged.

Signed-off-by: David Calavera <david.calavera@gmail.com>