### PR TITLE
make restartpolicy.IsNone return true if restart policy name is null

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -176,7 +176,7 @@ type RestartPolicy struct {
 // IsNone indicates whether the container has the "no" restart policy.
 // This means the container will not automatically restart when exiting.
 func (rp *RestartPolicy) IsNone() bool {
-	return rp.Name == "no"
+	return rp.Name == "no" || rp.Name == ""
 }
 
 // IsAlways indicates whether the container has the "always" restart policy.


### PR DESCRIPTION
if create a container via API and does not set restart polciy, the restart
name is "", it should also be "no" restart policy.

relate to https://github.com/docker/docker/pull/21993
Signed-off-by: Lei Jitang <leijitang@huawei.com>