### PR TITLE
client: remove empty file

### DIFF
--- a/client/privileged.go
+++ b/client/privileged.go
@@ -1,1 +1,0 @@
-package client


### PR DESCRIPTION
The definition of `RequestPrivilegeFunc` has been moved elsewhere,
obseleting this file. Removing for general hygiene.

Signed-off-by: Stephen J Day <stephen.day@docker.com>