### PR TITLE
Update CopyToContainer method signature…

### DIFF
--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -30,17 +30,17 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 }
 
 // CopyToContainer copies content into the container filesystem.
-func (cli *Client) CopyToContainer(ctx context.Context, options types.CopyToContainerOptions) error {
+func (cli *Client) CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
 	query := url.Values{}
-	query.Set("path", filepath.ToSlash(options.Path)) // Normalize the paths used in the API.
+	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 	// Do not allow for an existing directory to be overwritten by a non-directory and vice versa.
 	if !options.AllowOverwriteDirWithFile {
 		query.Set("noOverwriteDirNonDir", "true")
 	}
 
-	path := fmt.Sprintf("/containers/%s/archive", options.ContainerID)
+	apiPath := fmt.Sprintf("/containers/%s/archive", container)
 
-	response, err := cli.putRaw(ctx, path, query, options.Content, nil)
+	response, err := cli.putRaw(ctx, apiPath, query, content, nil)
 	if err != nil {
 		return err
 	}
@@ -55,11 +55,11 @@ func (cli *Client) CopyToContainer(ctx context.Context, options types.CopyToCont
 
 // CopyFromContainer gets the content from the container and returns it as a Reader
 // to manipulate it in the host. It's up to the caller to close the reader.
-func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
+func (cli *Client) CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
 	query := make(url.Values, 1)
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
-	apiPath := fmt.Sprintf("/containers/%s/archive", containerID)
+	apiPath := fmt.Sprintf("/containers/%s/archive", container)
 	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
 		return nil, types.ContainerPathStat{}, err

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -89,7 +89,7 @@ func TestCopyToContainerError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.CopyToContainer(context.Background(), types.CopyToContainerOptions{})
+	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server error, got %v", err)
 	}
@@ -99,7 +99,7 @@ func TestCopyToContainerNotStatusOKError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusNoContent, "No content")),
 	}
-	err := client.CopyToContainer(context.Background(), types.CopyToContainerOptions{})
+	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), types.CopyToContainerOptions{})
 	if err == nil || err.Error() != "unexpected status code from daemon: 204" {
 		t.Fatalf("expected a unexpected status code error, got %v", err)
 	}
@@ -143,10 +143,8 @@ func TestCopyToContainer(t *testing.T) {
 			}, nil
 		}),
 	}
-	err := client.CopyToContainer(context.Background(), types.CopyToContainerOptions{
-		ContainerID: "container_id",
-		Path:        expectedPath,
-		Content:     bytes.NewReader([]byte("content")),
+	err := client.CopyToContainer(context.Background(), "container_id", expectedPath, bytes.NewReader([]byte("content")), types.CopyToContainerOptions{
+		AllowOverwriteDirWithFile: false,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/client/interface.go
+++ b/client/interface.go
@@ -44,7 +44,7 @@ type APIClient interface {
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error
 	ContainerWait(ctx context.Context, container string) (int, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
-	CopyToContainer(ctx context.Context, options types.CopyToContainerOptions) error
+	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
 	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)

--- a/types/client.go
+++ b/types/client.go
@@ -69,9 +69,6 @@ type ContainerRemoveOptions struct {
 // CopyToContainerOptions holds information
 // about files to copy into a container
 type CopyToContainerOptions struct {
-	ContainerID               string
-	Path                      string
-	Content                   io.Reader
 	AllowOverwriteDirWithFile bool
 }
 


### PR DESCRIPTION
… to define the required arguments needed to be called 🐙. It makes it closer to `ContainerStatPath` too.

I think I missed this one from my previous PR :sweat:.

/cc @stevvooe @calavera @MHBauer 

🐸 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>