### PR TITLE
Update GetTagFromNamedRef to return latest…

### DIFF
--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -27,7 +27,7 @@ func (cli *Client) ImagePull(ctx context.Context, ref string, options types.Imag
 
 	query := url.Values{}
 	query.Set("fromImage", repository)
-	if tag != "" {
+	if tag != "" && !options.All {
 		query.Set("tag", tag)
 	}
 

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -10,7 +10,6 @@ import (
 
 	distreference "github.com/docker/distribution/reference"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/reference"
 )
 
 // ImagePush requests the docker host to push an image to a remote registry.
@@ -27,7 +26,10 @@ func (cli *Client) ImagePush(ctx context.Context, ref string, options types.Imag
 		return nil, errors.New("cannot push a digest reference")
 	}
 
-	tag := reference.GetTagFromNamedRef(distributionRef)
+	var tag = ""
+	if nameTaggedRef, isNamedTagged := distributionRef.(distreference.NamedTagged); isNamedTagged {
+		tag = nameTaggedRef.Tag()
+	}
 
 	query := url.Values{}
 	query.Set("tag", tag)

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -66,7 +66,7 @@ func TestImageTag(t *testing.T) {
 			expectedQueryParams: map[string]string{
 				"force": "1",
 				"repo":  "another_repository",
-				"tag":   "",
+				"tag":   "latest",
 			},
 		}, {
 			force:     true,
@@ -74,7 +74,7 @@ func TestImageTag(t *testing.T) {
 			expectedQueryParams: map[string]string{
 				"force": "1",
 				"repo":  "test/another_repository",
-				"tag":   "",
+				"tag":   "latest",
 			},
 		}, {
 			force:     true,
@@ -106,7 +106,7 @@ func TestImageTag(t *testing.T) {
 			expectedQueryParams: map[string]string{
 				"force": "1",
 				"repo":  "test:5000/test/another_repository",
-				"tag":   "",
+				"tag":   "latest",
 			},
 		},
 	}

--- a/types/client.go
+++ b/types/client.go
@@ -178,6 +178,7 @@ type ImageLoadResponse struct {
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {
+	All           bool
 	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
 	PrivilegeFunc RequestPrivilegeFunc
 }

--- a/types/reference/image_reference.go
+++ b/types/reference/image_reference.go
@@ -27,6 +27,8 @@ func GetTagFromNamedRef(ref distreference.Named) string {
 		tag = x.Digest().String()
 	case distreference.NamedTagged:
 		tag = x.Tag()
+	default:
+		tag = "latest"
 	}
 	return tag
 }

--- a/types/reference/image_reference_test.go
+++ b/types/reference/image_reference_test.go
@@ -1,0 +1,72 @@
+package reference
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		ref           string
+		expectedName  string
+		expectedTag   string
+		expectedError bool
+	}{
+		{
+			ref:           "",
+			expectedName:  "",
+			expectedTag:   "",
+			expectedError: true,
+		},
+		{
+			ref:           "repository",
+			expectedName:  "repository",
+			expectedTag:   "latest",
+			expectedError: false,
+		},
+		{
+			ref:           "repository:tag",
+			expectedName:  "repository",
+			expectedTag:   "tag",
+			expectedError: false,
+		},
+		{
+			ref:           "test.com/repository",
+			expectedName:  "test.com/repository",
+			expectedTag:   "latest",
+			expectedError: false,
+		},
+		{
+			ref:           "test.com:5000/test/repository",
+			expectedName:  "test.com:5000/test/repository",
+			expectedTag:   "latest",
+			expectedError: false,
+		},
+		{
+			ref:           "test.com:5000/repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			expectedName:  "test.com:5000/repo",
+			expectedTag:   "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			expectedError: false,
+		},
+		{
+			ref:           "test.com:5000/repo:tag@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			expectedName:  "test.com:5000/repo",
+			expectedTag:   "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			expectedError: false,
+		},
+	}
+
+	for _, c := range testCases {
+		name, tag, err := Parse(c.ref)
+		if err != nil && c.expectedError {
+			continue
+		} else if err != nil {
+			t.Fatalf("error with %s: %s", c.ref, err.Error())
+		}
+		if name != c.expectedName {
+			t.Fatalf("expected name %s, got %s", c.expectedName, name)
+		}
+		if tag != c.expectedTag {
+			t.Fatalf("expected tag %s, got %s", c.expectedTag, tag)
+		}
+	}
+}


### PR DESCRIPTION
… in case of no tag in the reference 🐰. 

Right now, if you pass a reference without a tag will send a request without tag to the daemon and thus the daemon will download all tags for this repository. `docker/docker` adds the default `latest` tag if it has not been and if `--all` is not defined.

I'm not sure this is the right place for it, waiting for your input. This change would break the way `--all` works, and the 2nd commits adds a more explicit way to specify we want to download all tags (putting it in option). If we decide to go this route, I'll do the PR in `docker/docker` to update the server side API.

/cc @stevvooe @calavera @MHBauer 

This also adds some unit test for this package 🐙.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>