### PR TITLE
Remove omitempty from AuthConfig.Email

### DIFF
--- a/types/auth.go
+++ b/types/auth.go
@@ -9,7 +9,7 @@ type AuthConfig struct {
 	// Email is an optional value associated with the username.
 	// This field is deprecated and will be removed in a later
 	// version of docker.
-	Email string `json:"email,omitempty"`
+	Email string `json:"email"`
 
 	ServerAddress string `json:"serveraddress,omitempty"`
 


### PR DESCRIPTION
In issue https://github.com/docker/docker/issues/22165 when the email field is missing from the auth config in `~/.docker/config.json` it is causing problems with older versions of docker-compose.

This fix removes `omitempty` from AuthConfig.Email, so that we write an empty Email field to the config.json file. I'm not 100% sure this will fix the issue with compose. 

This PR is mostly to start the discussion, if it looks good to people, we can move forward.

Signed-off-by: Ken Cochrane <KenCochrane@gmail.com>