### PR TITLE
Add filter support for ImageSearch

### DIFF
--- a/client/image_search.go
+++ b/client/image_search.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/registry"
 	"golang.org/x/net/context"
 )
@@ -16,6 +17,14 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)
+
+	if options.Filters.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filters)
+		if err != nil {
+			return results, err
+		}
+		query.Set("filters", filterJSON)
+	}
 
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
 	if resp.statusCode == http.StatusUnauthorized {

--- a/types/client.go
+++ b/types/client.go
@@ -205,6 +205,7 @@ type ImageRemoveOptions struct {
 type ImageSearchOptions struct {
 	RegistryAuth  string
 	PrivilegeFunc RequestPrivilegeFunc
+	Filters       filters.Args
 }
 
 // ImageTagOptions holds parameters to tag an image


### PR DESCRIPTION
Add support for filtering *daemon-side* the search outupts 🐭.

The related PR in docker is docker/docker#22369 ; carrying docker/docker#20574.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>