### PR TITLE
Add `Details` field for logs

### DIFF
--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -35,6 +35,10 @@ func (cli *Client) ContainerLogs(ctx context.Context, container string, options 
 		query.Set("timestamps", "1")
 	}
 
+	if options.Details {
+		query.Set("details", "1")
+	}
+
 	if options.Follow {
 		query.Set("follow", "1")
 	}

--- a/types/client.go
+++ b/types/client.go
@@ -57,6 +57,7 @@ type ContainerLogsOptions struct {
 	Timestamps bool
 	Follow     bool
 	Tail       string
+	Details    bool
 }
 
 // ContainerRemoveOptions holds parameters to remove containers.


### PR DESCRIPTION
`Details` instructs the backend you want the extra logged details when reading
logs, like labels, env, etc.

For docker/docker#21889