### PR TITLE
Complete unit tests with expectedURL

### DIFF
--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/docker/engine-api/types"
@@ -23,6 +24,7 @@ func TestContainerCommitError(t *testing.T) {
 }
 
 func TestContainerCommit(t *testing.T) {
+	expectedURL := "/commit"
 	expectedContainerID := "container_id"
 	specifiedReference := "repository_name:tag"
 	expectedRepositoryName := "repository_name"
@@ -33,6 +35,9 @@ func TestContainerCommit(t *testing.T) {
 
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			query := req.URL.Query()
 			containerID := query.Get("container")
 			if containerID != expectedContainerID {

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/docker/engine-api/types"
@@ -43,8 +44,12 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 }
 
 func TestContainerCreateWithName(t *testing.T) {
+	expectedURL := "/containers/create"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			name := req.URL.Query().Get("name")
 			if name != "container_name" {
 				return nil, fmt.Errorf("container name not set in URL query properly. Expected `container_name`, got %s", name)

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -3,8 +3,10 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/docker/engine-api/types"
@@ -23,8 +25,12 @@ func TestContainerDiffError(t *testing.T) {
 }
 
 func TestContainerDiff(t *testing.T) {
+	expectedURL := "/containers/container_id/changes"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			b, err := json.Marshal([]types.ContainerChange{
 				{
 					Kind: 0,

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -80,8 +80,12 @@ func TestContainerExecStartError(t *testing.T) {
 }
 
 func TestContainerExecStart(t *testing.T) {
+	expectedURL := "/exec/exec_id/start"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			if err := req.ParseForm(); err != nil {
 				return nil, err
 			}
@@ -120,8 +124,12 @@ func TestContainerExecInspectError(t *testing.T) {
 }
 
 func TestContainerExecInspect(t *testing.T) {
+	expectedURL := "/exec/exec_id/json"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			b, err := json.Marshal(types.ContainerExecInspect{
 				ExecID:      "exec_id",
 				ContainerID: "container_id",

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -3,8 +3,10 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/docker/engine-api/types"
@@ -34,8 +36,12 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 }
 
 func TestContainerInspect(t *testing.T) {
+	expectedURL := "/containers/container_id/json"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			content, err := json.Marshal(types.ContainerJSON{
 				ContainerJSONBase: &types.ContainerJSONBase{
 					ID:    "container_id",

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -21,8 +22,12 @@ func TestContainerKillError(t *testing.T) {
 }
 
 func TestContainerKill(t *testing.T) {
+	expectedURL := "/containers/container_id/kill"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			signal := req.URL.Query().Get("signal")
 			if signal != "SIGKILL" {
 				return nil, fmt.Errorf("signal not set in URL query properly. Expected 'SIGKILL', got %s", signal)

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -22,8 +23,12 @@ func TestContainerStartError(t *testing.T) {
 }
 
 func TestContainerStart(t *testing.T) {
+	expectedURL := "/containers/container_id/start"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			// we're not expecting any payload, but if one is supplied, check it is valid.
 			if req.Header.Get("Content-Type") == "application/json" {
 				var startConfig interface{}

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -21,8 +22,12 @@ func TestContainerStopError(t *testing.T) {
 }
 
 func TestContainerStop(t *testing.T) {
+	expectedURL := "/containers/container_id/stop"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			t := req.URL.Query().Get("t")
 			if t != "100" {
 				return nil, fmt.Errorf("t (timeout) not set in URL query properly. Expected '100', got %s", t)

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/docker/engine-api/types"
@@ -24,6 +25,7 @@ func TestContainerTopError(t *testing.T) {
 }
 
 func TestContainerTop(t *testing.T) {
+	expectedURL := "/containers/container_id/top"
 	expectedProcesses := [][]string{
 		{"p1", "p2"},
 		{"p3"},
@@ -32,6 +34,9 @@ func TestContainerTop(t *testing.T) {
 
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
 			query := req.URL.Query()
 			args := query.Get("ps_args")
 			if args != "arg1 arg2" {


### PR DESCRIPTION
Complete existing unit test to add a check to the expected url 🐭. This makes all tests a little bit more coherent :angel:.

/cc @calavera @stevvooe @MHBauer @LK4D4 @runcom @thaJeztah 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>