### PR TITLE
Add DaemonEventType so that daemon events could be emitted

### DIFF
--- a/types/events/events.go
+++ b/types/events/events.go
@@ -9,6 +9,8 @@ const (
 	VolumeEventType = "volume"
 	// NetworkEventType is the event type that networks generate
 	NetworkEventType = "network"
+	// DaemonEventType is the event type that daemon generate
+	DaemonEventType = "daemon"
 )
 
 // Actor describes something that generates events,


### PR DESCRIPTION
This fix tries to add a new event type `DaemonEventType` so that daemon events `daemon reload` could be emitted in docker.

This fix is related to

https://github.com/docker/docker/issues/22463
and
https://github.com/docker/docker/pull/22590

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>