### PR TITLE
Add a new UniqueExactMatch method to filters

### DIFF
--- a/types/filters/parse.go
+++ b/types/filters/parse.go
@@ -215,10 +215,22 @@ func (filters Args) ExactMatch(field, source string) bool {
 	}
 
 	// try to match full name value to avoid O(N) regular expression matching
-	if fieldValues[source] {
+	return fieldValues[source]
+}
+
+// UniqueExactMatch returns true if there is only one filter and the source matches exactly this one.
+func (filters Args) UniqueExactMatch(field, source string) bool {
+	fieldValues := filters.fields[field]
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
 		return true
 	}
-	return false
+	if len(filters.fields[field]) != 1 {
+		return false
+	}
+
+	// try to match full name value to avoid O(N) regular expression matching
+	return fieldValues[source]
 }
 
 // FuzzyMatch returns true if the source matches exactly one of the filters,

--- a/types/filters/parse_test.go
+++ b/types/filters/parse_test.go
@@ -318,6 +318,29 @@ func TestExactMatch(t *testing.T) {
 	}
 }
 
+func TestOnlyOneExactMatch(t *testing.T) {
+	f := NewArgs()
+
+	if !f.UniqueExactMatch("status", "running") {
+		t.Fatalf("Expected to match `running` when there are no filters, got false")
+	}
+
+	f.Add("status", "running")
+
+	if !f.UniqueExactMatch("status", "running") {
+		t.Fatalf("Expected to match `running` with one of the filters, got false")
+	}
+
+	if f.UniqueExactMatch("status", "paused") {
+		t.Fatalf("Expected to not match `paused` with one of the filters, got true")
+	}
+
+	f.Add("status", "pause")
+	if f.UniqueExactMatch("status", "running") {
+		t.Fatalf("Expected to not match only `running` with two filters, got true")
+	}
+}
+
 func TestInclude(t *testing.T) {
 	f := NewArgs()
 	if f.Include("status") {


### PR DESCRIPTION
It let us the possibility to validate that the filter is only present once and thus can help validating boolean filters better 🐳.

For example, in docker/docker, right now, it is possible to pass multiple filter values for the `dangling` boolean filter even if they are not valid (i.e. `--filter=dangling=toto --filter=dangling=true` will work even though we wanted only one value and a valid one).

This is related to the following comment : https://github.com/docker/docker/pull/22369#issuecomment-219983718 ; not sure if this is the best way to handle this use case, but I feel `filters` should give us an easy way to validate that the filter has/should have only one valid value.

/cc @calavera @stevvooe @LK4D4 @runcom @thaJeztah 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>