### PR TITLE
Use filters.ToParamWithVersion elsewhere

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -33,7 +33,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (io.
 		query.Set("until", ts)
 	}
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -15,7 +15,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return images, err
 		}

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -13,7 +13,7 @@ import (
 func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -15,7 +15,7 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (types.V
 	query := url.Values{}
 
 	if filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
 		if err != nil {
 			return volumes, err
 		}


### PR DESCRIPTION
`ToParamWithVersion` allows to serialize correctly filters for oldeversion of docker (1.9.1 and lower mainly). It is currently only use for `ContainerList` but it's not the only place where the filters happens 🐰.

This make use of `ToParamWithVersion` for `ImageList`, `VolumesList`, `NetworkList` and `Events` as well (all where filters where already there in 1.9.1).

/cc @calavera @stevvooe @LK4D4 @runcom @thaJeztah

It's the reason behind https://github.com/containous/traefik/issues/360 and I'm pretty sure it could be reproduced using the official docker client. 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>