### PR TITLE
Use time.Duration as type for timeouts

### DIFF
--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -2,17 +2,18 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	query.Set("t", timetypes.DurationToSecondsString(timeout))
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 )
@@ -15,7 +16,7 @@ func TestContainerRestartError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerRestart(context.Background(), "nothing", 0)
+	err := client.ContainerRestart(context.Background(), "nothing", 0*time.Second)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -39,7 +40,7 @@ func TestContainerRestart(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerRestart(context.Background(), "container_id", 100)
+	err := client.ContainerRestart(context.Background(), "container_id", 100*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -2,16 +2,17 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	query.Set("t", timetypes.DurationToSecondsString(timeout))
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 )
@@ -15,7 +16,7 @@ func TestContainerStopError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerStop(context.Background(), "nothing", 0)
+	err := client.ContainerStop(context.Background(), "nothing", 0*time.Second)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -39,7 +40,7 @@ func TestContainerStop(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerStop(context.Background(), "container_id", 100)
+	err := client.ContainerStop(context.Background(), "container_id", 100*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"io"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -37,11 +38,11 @@ type APIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout int) error
+	ContainerRestart(ctx context.Context, container string, timeout time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
-	ContainerStop(ctx context.Context, container string, timeout int) error
+	ContainerStop(ctx context.Context, container string, timeout time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error

--- a/types/time/duration_convert.go
+++ b/types/time/duration_convert.go
@@ -1,0 +1,12 @@
+package time
+
+import (
+	"strconv"
+	"time"
+)
+
+// DurationToSecondsString converts the specified duration to the number
+// seconds it represents, formatted as a string.
+func DurationToSecondsString(duration time.Duration) string {
+	return strconv.FormatFloat(duration.Seconds(), 'f', 0, 64)
+}

--- a/types/time/duration_convert_test.go
+++ b/types/time/duration_convert_test.go
@@ -1,0 +1,26 @@
+package time
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDurationToSecondsString(t *testing.T) {
+	cases := []struct {
+		in       time.Duration
+		expected string
+	}{
+		{0 * time.Second, "0"},
+		{1 * time.Second, "1"},
+		{1 * time.Minute, "60"},
+		{24 * time.Hour, "86400"},
+	}
+
+	for _, c := range cases {
+		s := DurationToSecondsString(c.in)
+		if s != c.expected {
+			t.Errorf("wrong value for input `%v`: expected `%s`, got `%s`", c.in, c.expected, s)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
This PR replaces instances of where timeout was an `int` representing the number of seconds by `time.Duration`, as suggested by #230 .
Not entirely sure about the float64 -> int conversion, also thought about using `strconv.FormatFloat(v, 'f', 0, 64)` for formatting it as an integer. WDYT ?