### PR TITLE
Update types to support HEALTHCHECK feature

### DIFF
--- a/types/container/config.go
+++ b/types/container/config.go
@@ -3,7 +3,28 @@ package container
 import (
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/docker/go-connections/nat"
+	"time"
 )
+
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test to perform to check container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test strslice.StrSlice `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval time.Duration `json:",omitempty"` // Time to wait between checks.
+	Timeout  time.Duration `json:",omitempty"` // Time to wait before considering the check to have hung.
+
+	// Number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries uint `json:",omitempty"`
+}
 
 // Config contains the configuration data about a container.
 // It should hold only portable information about the container.
@@ -24,6 +45,7 @@ type Config struct {
 	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
 	Env             []string              // List of environment variable to set in the container
 	Cmd             strslice.StrSlice     // Command to run when starting the container
+	Healthcheck     *HealthConfig         `json:",omitempty"` // Command to run to check container is healthy
 	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
 	Image           string                // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container

--- a/types/container/config.go
+++ b/types/container/config.go
@@ -15,7 +15,7 @@ type HealthConfig struct {
 	// {"NONE"} : disable healthcheck
 	// {"CMD", args...} : exec arguments directly
 	// {"CMD-SHELL", command} : run command with system's default shell
-	Test strslice.StrSlice `json:",omitempty"`
+	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
 	Interval time.Duration `json:",omitempty"` // Time to wait between checks.
@@ -23,7 +23,7 @@ type HealthConfig struct {
 
 	// Number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
-	Retries uint `json:",omitempty"`
+	Retries int `json:",omitempty"`
 }
 
 // Config contains the configuration data about a container.

--- a/types/container/config.go
+++ b/types/container/config.go
@@ -8,7 +8,7 @@ import (
 
 // HealthConfig holds configuration settings for the HEALTHCHECK feature.
 type HealthConfig struct {
-	// Test to perform to check container is healthy.
+	// Test is the test to perform to check that the container is healthy.
 	// An empty slice means to inherit the default.
 	// The options are:
 	// {} : inherit healthcheck
@@ -18,10 +18,10 @@ type HealthConfig struct {
 	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval time.Duration `json:",omitempty"` // Time to wait between checks.
-	Timeout  time.Duration `json:",omitempty"` // Time to wait before considering the check to have hung.
+	Interval time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout  time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
 
-	// Number of consecutive failures needed to consider a container as unhealthy.
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
 	Retries int `json:",omitempty"`
 }
@@ -45,7 +45,7 @@ type Config struct {
 	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
 	Env             []string              // List of environment variable to set in the container
 	Cmd             strslice.StrSlice     // Command to run when starting the container
-	Healthcheck     *HealthConfig         `json:",omitempty"` // Command to run to check container is healthy
+	Healthcheck     *HealthConfig         `json:",omitempty"` // Healthcheck describes how to check the container is healthy
 	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
 	Image           string                // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container

--- a/types/types.go
+++ b/types/types.go
@@ -281,9 +281,16 @@ type HealthcheckResult struct {
 	Output     string // Output from last check
 }
 
+// Health states
+const (
+	Starting  = "starting"  // Container is not yet ready
+	Healthy   = "healthy"   // Container is running correctly
+	Unhealthy = "unhealthy" // Container has a problem
+)
+
 // Health stores information about the container's healthcheck results
 type Health struct {
-	Status        string               // States are: "starting", "healthy", "unhealthy"
+	Status        string               // Possible states are: Starting, Healthy and Unhealthy
 	FailingStreak int                  // Number of consecutive failures
 	Log           []*HealthcheckResult // The last few results (oldest first)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -274,6 +274,20 @@ type ExecStartCheck struct {
 	Tty bool
 }
 
+// HealthcheckResult stores information about a single run of a healthcheck probe
+type HealthcheckResult struct {
+	Start, End time.Time
+	ExitCode   int    // 0=healthy, 1=unhealthy, 2=starting, -1=error running probe
+	Output     string // Output from last check
+}
+
+// Health stores information about the container's healthcheck results
+type Health struct {
+	Status        string               // States are: "starting", "healthy", "unhealthy"
+	FailingStreak uint64               // Number of consecutive failures
+	Log           []*HealthcheckResult // The last few results (oldest first)
+}
+
 // ContainerState stores container's running state
 // it's part of ContainerJSONBase and will return by "inspect" command
 type ContainerState struct {
@@ -288,6 +302,7 @@ type ContainerState struct {
 	Error      string
 	StartedAt  string
 	FinishedAt string
+	Health     *Health `json:",omitempty"`
 }
 
 // ContainerNode stores information about the node that a container

--- a/types/types.go
+++ b/types/types.go
@@ -276,23 +276,24 @@ type ExecStartCheck struct {
 
 // HealthcheckResult stores information about a single run of a healthcheck probe
 type HealthcheckResult struct {
-	Start, End time.Time
-	ExitCode   int    // 0=healthy, 1=unhealthy, 2=starting, else=error running probe
-	Output     string // Output from last check
+	Start    time.Time // Start is the time this check started
+	End      time.Time // End is the time this check ended
+	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=starting, else=error running probe
+	Output   string    // Output from last check
 }
 
 // Health states
 const (
-	Starting  = "starting"  // Container is not yet ready
-	Healthy   = "healthy"   // Container is running correctly
-	Unhealthy = "unhealthy" // Container has a problem
+	Starting  = "starting"  // Starting indicates that the container is not yet ready
+	Healthy   = "healthy"   // Healthy indicates that the container is running correctly
+	Unhealthy = "unhealthy" // Unhealthy indicates that the container has a problem
 )
 
 // Health stores information about the container's healthcheck results
 type Health struct {
-	Status        string               // Possible states are: Starting, Healthy and Unhealthy
-	FailingStreak int                  // Number of consecutive failures
-	Log           []*HealthcheckResult // The last few results (oldest first)
+	Status        string               // Status is one of Starting, Healthy or Unhealthy
+	FailingStreak int                  // FailingStreak is the number of consecutive failures
+	Log           []*HealthcheckResult // Log contains the last few results (oldest first)
 }
 
 // ContainerState stores container's running state

--- a/types/types.go
+++ b/types/types.go
@@ -277,14 +277,14 @@ type ExecStartCheck struct {
 // HealthcheckResult stores information about a single run of a healthcheck probe
 type HealthcheckResult struct {
 	Start, End time.Time
-	ExitCode   int    // 0=healthy, 1=unhealthy, 2=starting, -1=error running probe
+	ExitCode   int    // 0=healthy, 1=unhealthy, 2=starting, else=error running probe
 	Output     string // Output from last check
 }
 
 // Health stores information about the container's healthcheck results
 type Health struct {
 	Status        string               // States are: "starting", "healthy", "unhealthy"
-	FailingStreak uint64               // Number of consecutive failures
+	FailingStreak int                  // Number of consecutive failures
 	Log           []*HealthcheckResult // The last few results (oldest first)
 }
 


### PR DESCRIPTION
Moving the engine-api changes in https://github.com/docker/docker/pull/22719 here for discussion.

I changed the units for time intervals from seconds to integer nanoseconds, and made `Health` include a list of results rather than just the last one, based on comments there. Two other comments (so they don't get lost) were:

- A request to split `Test` into two fields (this was for an older version of the type). I'm not quite sure what this would look like with the current type. It might make the inheritance rules more complex (e.g. it would allow the caller to ask for a different type of test but with the same arguments).

- A request to allow the `Retries` field to accept negative values.