### PR TITLE
Make NotFound Errors exportable

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -8,26 +8,47 @@ import (
 // ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
+type notFound interface {
+	error
+	NotFound() bool // Is the error a NotFound error
+}
+
+// IsErrNotFound returns true if the error is caused with an
+// object (image, container, network, volume, …) is not found in the docker host.
+func IsErrNotFound(err error) bool {
+	te, ok := err.(notFound)
+	return ok && te.NotFound()
+}
+
 // imageNotFoundError implements an error returned when an image is not in the docker host.
 type imageNotFoundError struct {
 	imageID string
 }
 
+// NoFound indicates that this error type is of NotFound
+func (e imageNotFoundError) NotFound() bool {
+	return true
+}
+
 // Error returns a string representation of an imageNotFoundError
-func (i imageNotFoundError) Error() string {
-	return fmt.Sprintf("Error: No such image: %s", i.imageID)
+func (e imageNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such image: %s", e.imageID)
 }
 
 // IsErrImageNotFound returns true if the error is caused
 // when an image is not found in the docker host.
 func IsErrImageNotFound(err error) bool {
-	_, ok := err.(imageNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // containerNotFoundError implements an error returned when a container is not in the docker host.
 type containerNotFoundError struct {
 	containerID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e containerNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a containerNotFoundError
@@ -38,13 +59,17 @@ func (e containerNotFoundError) Error() string {
 // IsErrContainerNotFound returns true if the error is caused
 // when a container is not found in the docker host.
 func IsErrContainerNotFound(err error) bool {
-	_, ok := err.(containerNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // networkNotFoundError implements an error returned when a network is not in the docker host.
 type networkNotFoundError struct {
 	networkID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e networkNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -55,13 +80,17 @@ func (e networkNotFoundError) Error() string {
 // IsErrNetworkNotFound returns true if the error is caused
 // when a network is not found in the docker host.
 func IsErrNetworkNotFound(err error) bool {
-	_, ok := err.(networkNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // volumeNotFoundError implements an error returned when a volume is not in the docker host.
 type volumeNotFoundError struct {
 	volumeID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e volumeNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -72,8 +101,7 @@ func (e volumeNotFoundError) Error() string {
 // IsErrVolumeNotFound returns true if the error is caused
 // when a volume is not found in the docker host.
 func IsErrVolumeNotFound(err error) bool {
-	_, ok := err.(volumeNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // unauthorizedError represents an authorization error in a remote registry.


### PR DESCRIPTION
If they are not exportable, it's impossible to write unit-test on library using `engine-api` that would return an `imageNotFoundError` or other NotFoundErrors 🐹.

This is a naive approach and I'm not sure this is the right one either. But somehow, in some unit-test in `libcompose` I need to make my client returning a `networkNotFoundError` (or the same for other types) and there is currently no way I can do that (or I'm missing something :stuck_out_tongue_closed_eyes: ).

/cc @calavera @LK4D4 @runcom @stevvooe 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>