### PR TITLE
Remove deprecated -f flag on docker tag

### DIFF
--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -8,12 +8,11 @@ import (
 	"golang.org/x/net/context"
 
 	distreference "github.com/docker/distribution/reference"
-	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/reference"
 )
 
 // ImageTag tags an image in the docker host
-func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options types.ImageTagOptions) error {
+func (cli *Client) ImageTag(ctx context.Context, imageID, ref string) error {
 	distributionRef, err := distreference.ParseNamed(ref)
 	if err != nil {
 		return fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", ref)
@@ -28,9 +27,6 @@ func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options ty
 	query := url.Values{}
 	query.Set("repo", distributionRef.Name())
 	query.Set("tag", tag)
-	if options.Force {
-		query.Set("force", "1")
-	}
 
 	resp, err := cli.post(ctx, "/images/"+imageID+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"golang.org/x/net/context"
-
-	"github.com/docker/engine-api/types"
 )
 
 func TestImageTagError(t *testing.T) {
@@ -18,7 +16,7 @@ func TestImageTagError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.ImageTag(context.Background(), "image_id", "repo:tag", types.ImageTagOptions{})
+	err := client.ImageTag(context.Background(), "image_id", "repo:tag")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -31,7 +29,7 @@ func TestImageTagInvalidReference(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.ImageTag(context.Background(), "image_id", "aa/asdf$$^/aa", types.ImageTagOptions{})
+	err := client.ImageTag(context.Background(), "image_id", "aa/asdf$$^/aa")
 	if err == nil || err.Error() != `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag` {
 		t.Fatalf("expected ErrReferenceInvalidFormat, got %v", err)
 	}
@@ -40,73 +38,56 @@ func TestImageTagInvalidReference(t *testing.T) {
 func TestImageTag(t *testing.T) {
 	expectedURL := "/images/image_id/tag"
 	tagCases := []struct {
-		force               bool
 		reference           string
 		expectedQueryParams map[string]string
 	}{
 		{
-			force:     false,
 			reference: "repository:tag1",
 			expectedQueryParams: map[string]string{
-				"force": "",
-				"repo":  "repository",
-				"tag":   "tag1",
+				"repo": "repository",
+				"tag":  "tag1",
 			},
 		}, {
-			force:     true,
 			reference: "another_repository:latest",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "another_repository",
-				"tag":   "latest",
+				"repo": "another_repository",
+				"tag":  "latest",
 			},
 		}, {
-			force:     true,
 			reference: "another_repository",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "another_repository",
-				"tag":   "latest",
+				"repo": "another_repository",
+				"tag":  "latest",
 			},
 		}, {
-			force:     true,
 			reference: "test/another_repository",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "test/another_repository",
-				"tag":   "latest",
+				"repo": "test/another_repository",
+				"tag":  "latest",
 			},
 		}, {
-			force:     true,
 			reference: "test/another_repository:tag1",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "test/another_repository",
-				"tag":   "tag1",
+				"repo": "test/another_repository",
+				"tag":  "tag1",
 			},
 		}, {
-			force:     true,
 			reference: "test/test/another_repository:tag1",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "test/test/another_repository",
-				"tag":   "tag1",
+				"repo": "test/test/another_repository",
+				"tag":  "tag1",
 			},
 		}, {
-			force:     true,
 			reference: "test:5000/test/another_repository:tag1",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "test:5000/test/another_repository",
-				"tag":   "tag1",
+				"repo": "test:5000/test/another_repository",
+				"tag":  "tag1",
 			},
 		}, {
-			force:     true,
 			reference: "test:5000/test/another_repository",
 			expectedQueryParams: map[string]string{
-				"force": "1",
-				"repo":  "test:5000/test/another_repository",
-				"tag":   "latest",
+				"repo": "test:5000/test/another_repository",
+				"tag":  "latest",
 			},
 		},
 	}
@@ -132,9 +113,7 @@ func TestImageTag(t *testing.T) {
 				}, nil
 			}),
 		}
-		err := client.ImageTag(context.Background(), "image_id", tagCase.reference, types.ImageTagOptions{
-			Force: tagCase.force,
-		})
+		err := client.ImageTag(context.Background(), "image_id", tagCase.reference)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/interface.go
+++ b/client/interface.go
@@ -61,7 +61,7 @@ type APIClient interface {
 	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDelete, error)
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
-	ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error
+	ImageTag(ctx context.Context, image, ref string) error
 	Info(ctx context.Context) (types.Info, error)
 	NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)

--- a/types/client.go
+++ b/types/client.go
@@ -215,11 +215,6 @@ type ImageSearchOptions struct {
 	Filters       filters.Args
 }
 
-// ImageTagOptions holds parameters to tag an image
-type ImageTagOptions struct {
-	Force bool
-}
-
 // ResizeOptions holds parameters to resize a tty.
 // It can be used to resize container ttys and
 // exec process ttys too.


### PR DESCRIPTION
This fix is related to docker:
https://github.com/docker/docker/pull/23090

The -f flag on docker tag has been deprecated in docker 1.10 and is expected to be removed in docker 1.12.

This fix updated the associated files in engine-api.

Related tests have also been updated.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>