### PR TITLE
Only set url value when it's not empty

### DIFF
--- a/client/container_start.go
+++ b/client/container_start.go
@@ -4,12 +4,16 @@ import (
 	"net/url"
 
 	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/types"
 )
 
 // ContainerStart sends a request to the docker daemon to start a container.
-func (cli *Client) ContainerStart(ctx context.Context, containerID string, checkpointID string) error {
+func (cli *Client) ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error {
 	query := url.Values{}
-	query.Set("checkpoint", checkpointID)
+	if len(options.CheckpointID) != 0 {
+		query.Set("checkpoint", options.CheckpointID)
+	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -10,13 +10,15 @@ import (
 	"testing"
 
 	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/types"
 )
 
 func TestContainerStartError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerStart(context.Background(), "nothing", "")
+	err := client.ContainerStart(context.Background(), "nothing", types.ContainerStartOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -49,7 +51,7 @@ func TestContainerStart(t *testing.T) {
 		}),
 	}
 
-	err := client.ContainerStart(context.Background(), "container_id", "checkpoint_id")
+	err := client.ContainerStart(context.Background(), "container_id", types.ContainerStartOptions{CheckpointID: "checkpoint_id"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -40,7 +40,7 @@ type APIClient interface {
 	ContainerRestart(ctx context.Context, container string, timeout int) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
-	ContainerStart(ctx context.Context, container string, checkpointID string) error
+	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
 	ContainerStop(ctx context.Context, container string, timeout int) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error

--- a/types/client.go
+++ b/types/client.go
@@ -73,6 +73,11 @@ type ContainerRemoveOptions struct {
 	Force         bool
 }
 
+// ContainerStartOptions holds parameters to start containers.
+type ContainerStartOptions struct {
+	CheckpointID string
+}
+
 // CopyToContainerOptions holds information
 // about files to copy into a container
 type CopyToContainerOptions struct {


### PR DESCRIPTION
Only a small nit.
Currently docker start API always contains a trailing `checkpoint=` even
if value is empty, this is unnecessary, we can set it only when it's not
empty.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>