### PR TITLE
Add `--limit` option to `docker search`

### DIFF
--- a/client/image_search.go
+++ b/client/image_search.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -17,6 +18,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)
+	query.Set("limit", fmt.Sprintf("%d", options.Limit))
 
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToParam(options.Filters)

--- a/types/client.go
+++ b/types/client.go
@@ -213,6 +213,7 @@ type ImageSearchOptions struct {
 	RegistryAuth  string
 	PrivilegeFunc RequestPrivilegeFunc
 	Filters       filters.Args
+	Limit         int
 }
 
 // ResizeOptions holds parameters to resize a tty.


### PR DESCRIPTION
This fix is related to docker:
https://github.com/docker/docker/pull/23107
https://github.com/docker/docker/issues/23055

Currently docker search result caps at 25 and there is no way to allow getting more results (if exist).

This fix adds the flag --limit so that it is possible to return more results from the docker search.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>