### PR TITLE
Add support for using different OCI runtimes

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -308,7 +308,8 @@ type HostConfig struct {
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container
 	ShmSize         int64             // Total shm memory usage
-	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
+	Sysctls         map[string]string `json:",omitempty"`        // List of Namespaced sysctls used for the container
+	Runtime         string            `json:"runtime,omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
 	ConsoleSize [2]int    // Initial console size

--- a/types/types.go
+++ b/types/types.go
@@ -252,6 +252,8 @@ type Info struct {
 	ClusterStore       string
 	ClusterAdvertise   string
 	SecurityOptions    []string
+	Runtimes           map[string]Runtime
+	DefaultRuntime     string
 }
 
 // PluginsInfo is a temp struct holding Plugins name
@@ -475,4 +477,14 @@ type NetworkDisconnect struct {
 // Checkpoint represents the details of a checkpoint
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint
+}
+
+// DefaultRuntimeName is the reserved name/alias used to represent the
+// OCI runtime being shipped with the docker daemon package.
+var DefaultRuntimeName = "default"
+
+// Runtime describes an OCI runtime
+type Runtime struct {
+	Path string   `json:"path"`
+	Args []string `json:"runtimeArgs,omitempty"`
 }


### PR DESCRIPTION
Required by docker/docker#22983