### PR TITLE
Add shell to support SHELL in dockerfile

### DIFF
--- a/types/container/config.go
+++ b/types/container/config.go
@@ -1,9 +1,10 @@
 package container
 
 import (
+	"time"
+
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/docker/go-connections/nat"
-	"time"
 )
 
 // HealthConfig holds configuration settings for the HEALTHCHECK feature.
@@ -56,4 +57,5 @@ type Config struct {
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
 	StopSignal      string                `json:",omitempty"` // Signal to stop a container
+	Shell           strslice.StrSlice     `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

To support docker https://github.com/docker/docker/pull/22489 which adds the SHELL instruction to the docker engine builder.