### PR TITLE
Add config parameter to change per-container stop timeout during daemon shutdown

### DIFF
--- a/types/container/config.go
+++ b/types/container/config.go
@@ -57,5 +57,6 @@ type Config struct {
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
 	StopSignal      string                `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                  `json:",omitempty"` // Timeout (in seconds) to stop a container
 	Shell           strslice.StrSlice     `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }


### PR DESCRIPTION
This fix tries to add a `StopTimeout` in container's Config so that a per-container stop timeout could be specified during daemon shutdown.

The `StopTimeout` is defined as `*int` so that unspecified value could be correctly identified as using the default value (10s).
Note: Both `0` and `-1` could not be used as the default value because `0` means stop immediately and `-1` means wait forever.

This fix is related to docker:
https://github.com/docker/docker/pull/22566

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>