### PR TITLE
client: request: check only 'bad certificate'

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -112,7 +112,7 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)
 		}
 
-		if cli.transport.Secure() && strings.Contains(err.Error(), "remote error: bad certificate") {
+		if cli.transport.Secure() && strings.Contains(err.Error(), "bad certificate") {
 			return serverResp, fmt.Errorf("The server probably has client authentication (--tlsverify) enabled. Please check your TLS client certification settings: %v", err)
 		}
 


### PR DESCRIPTION
This is because go1.7+ now prints 'tls: ' before
https://github.com/golang/go/commit/eede112492174c8b0f72845e6ac9edf1bd481f41

Signed-off-by: Antonio Murdaca <runcom@redhat.com>