### PR TITLE
change Memory type to int64 in ContainerNode

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -323,7 +323,7 @@ type ContainerNode struct {
 	Addr      string
 	Name      string
 	Cpus      int
-	Memory    int
+	Memory    int64
 	Labels    map[string]string
 }
 


### PR DESCRIPTION
change Memory type to int64 in ContainerNode
As MemTotal in Info is int64, and I think engine-api should keep them the same.

Signed-off-by: allencloud <allen.sun@daocloud.io>