### PR TITLE
Adding support for real-time cgroup values

### DIFF
--- a/types/client.go
+++ b/types/client.go
@@ -137,6 +137,8 @@ type ImageBuildOptions struct {
 	CPUShares      int64
 	CPUQuota       int64
 	CPUPeriod      int64
+	CPURtPeriod    int64
+	CPURtRuntime   int64
 	Memory         int64
 	MemorySwap     int64
 	CgroupParent   string

--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -242,8 +242,10 @@ type Resources struct {
 	BlkioDeviceWriteBps  []*blkiodev.ThrottleDevice
 	BlkioDeviceReadIOps  []*blkiodev.ThrottleDevice
 	BlkioDeviceWriteIOps []*blkiodev.ThrottleDevice
-	CPUPeriod            int64           `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
-	CPUQuota             int64           `json:"CpuQuota"`  // CPU CFS (Completely Fair Scheduler) quota
+	CPUPeriod            int64           `json:"CpuPeriod"`    // CPU CFS (Completely Fair Scheduler) period
+	CPUQuota             int64           `json:"CpuQuota"`     // CPU CFS (Completely Fair Scheduler) quota
+	CPURtPeriod          int64           `json:"CpuRtPeriod"`  // CPU real-time period
+	CPURtRuntime         int64           `json:"CpuRtRuntime"` // CPU real-time runtime
 	CpusetCpus           string          // CpusetCpus 0-2, 0,1
 	CpusetMems           string          // CpusetMems 0-2, 0,1
 	Devices              []DeviceMapping // List of devices to map inside the container


### PR DESCRIPTION
This is required for an incoming PR I am submitting to docker/docker, so that users may supply `--cpu-rt-period` and `--cpu-rt-runtime` values so processes inside a container can set their realtime priority when the kernel option CONFIG_RT_GROUP_SCHED is configured.

This is discussed a bit towards the end of this issue https://github.com/docker/docker/issues/22380