### PR TITLE
Revert "Remove /json from API URLs"

### DIFF
--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -38,7 +38,7 @@ func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, confi
 // ContainerExecInspect returns information about a specific exec process on the docker host.
 func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error) {
 	var response types.ContainerExecInspect
-	resp, err := cli.get(ctx, "/exec/"+execID, nil, nil)
+	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
 	if err != nil {
 		return response, err
 	}

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -124,7 +124,7 @@ func TestContainerExecInspectError(t *testing.T) {
 }
 
 func TestContainerExecInspect(t *testing.T) {
-	expectedURL := "/exec/exec_id"
+	expectedURL := "/exec/exec_id/json"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -13,7 +13,7 @@ import (
 
 // ContainerInspect returns the container information.
 func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
-	serverResp, err := cli.get(ctx, "/containers/"+containerID, nil, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, containerNotFoundError{containerID}
@@ -33,7 +33,7 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get(ctx, "/containers/"+containerID, query, nil)
+	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ContainerJSON{}, nil, containerNotFoundError{containerID}

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -36,7 +36,7 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 }
 
 func TestContainerInspect(t *testing.T) {
-	expectedURL := "/containers/container_id"
+	expectedURL := "/containers/container_id/json"
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -44,7 +44,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 		query.Set("filters", filterJSON)
 	}
 
-	resp, err := cli.get(ctx, "/containers", query, nil)
+	resp, err := cli.get(ctx, "/containers/json", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -25,7 +25,7 @@ func TestContainerListError(t *testing.T) {
 }
 
 func TestContainerList(t *testing.T) {
-	expectedURL := "/containers"
+	expectedURL := "/containers/json"
 	expectedFilters := `{"before":{"container":true},"label":{"label1":true,"label2":true}}`
 	client := &Client{
 		transport: newMockClient(nil, func(req *http.Request) (*http.Response, error) {

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -17,7 +17,7 @@ func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string, getS
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get(ctx, "/images/"+imageID, query, nil)
+	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
 	if err != nil {
 		if serverResp.statusCode == http.StatusNotFound {
 			return types.ImageInspect{}, nil, imageNotFoundError{imageID}

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -37,7 +37,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 }
 
 func TestImageInspect(t *testing.T) {
-	expectedURL := "/images/image_id"
+	expectedURL := "/images/image_id/json"
 	expectedTags := []string{"tag1", "tag2"}
 	inspectCases := []struct {
 		size                bool

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -29,7 +29,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 		query.Set("all", "1")
 	}
 
-	serverResp, err := cli.get(ctx, "/images", query, nil)
+	serverResp, err := cli.get(ctx, "/images/json", query, nil)
 	if err != nil {
 		return images, err
 	}

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -26,7 +26,7 @@ func TestImageListError(t *testing.T) {
 }
 
 func TestImageList(t *testing.T) {
-	expectedURL := "/images"
+	expectedURL := "/images/json"
 
 	noDanglingfilters := filters.NewArgs()
 	noDanglingfilters.Add("dangling", "false")

--- a/types/types.go
+++ b/types/types.go
@@ -84,7 +84,7 @@ type ImageDelete struct {
 }
 
 // Image contains response of Remote API:
-// GET "/images"
+// GET "/images/json"
 type Image struct {
 	ID          string `json:"Id"`
 	ParentID    string `json:"ParentId"`
@@ -111,7 +111,7 @@ type RootFS struct {
 }
 
 // ImageInspect contains response of Remote API:
-// GET "/images/{name:.*}"
+// GET "/images/{name:.*}/json"
 type ImageInspect struct {
 	ID              string `json:"Id"`
 	RepoTags        []string
@@ -142,7 +142,7 @@ type Port struct {
 }
 
 // Container contains response of Remote API:
-// GET "/containers"
+// GET "/containers/json"
 type Container struct {
 	ID         string `json:"Id"`
 	Names      []string
@@ -328,7 +328,7 @@ type ContainerNode struct {
 }
 
 // ContainerJSONBase contains response of Remote API:
-// GET "/containers/{name:.*}"
+// GET "/containers/{name:.*}/json"
 type ContainerJSONBase struct {
 	ID              string `json:"Id"`
 	Created         string
@@ -370,7 +370,7 @@ type NetworkSettings struct {
 }
 
 // SummaryNetworkSettings provides a summary of container's networks
-// in /containers
+// in /containers/json
 type SummaryNetworkSettings struct {
 	Networks map[string]*network.EndpointSettings
 }


### PR DESCRIPTION
This reverts commit 73cef48eb73cbb422389bb98a340fca1bb9a3ba9.

It's breaking current uses of `engine-api`… We need to get back at this change with a better retro-compatibility way :angel: 

Really sorry about that `engine-api` users :bow: 