### PR TITLE
Add default version to NewEnvClient

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -72,9 +72,12 @@ func NewEnvClient() (*Client, error) {
 }
 
 // NewClient initializes a new API client for the given host and API version.
-// It won't send any version information if the version number is empty.
 // It uses the given http client as transport.
 // It also initializes the custom http headers to add to each request.
+//
+// It won't send any version information if the version number is empty. It is
+// highly recommended that you set a version or your client may break if the
+// server is upgraded.
 func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
 	proto, addr, basePath, err := ParseHost(host)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -12,6 +12,9 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
+// DefaultVersion is the version of the current stable API
+const DefaultVersion string = "1.23"
+
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
@@ -59,7 +62,13 @@ func NewEnvClient() (*Client, error) {
 	if host == "" {
 		host = DefaultDockerHost
 	}
-	return NewClient(host, os.Getenv("DOCKER_API_VERSION"), client, nil)
+
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		version = DefaultVersion
+	}
+
+	return NewClient(host, version, client, nil)
 }
 
 // NewClient initializes a new API client for the given host and API version.


### PR DESCRIPTION
Matches behaviour of CLI, and will stop apps breaking if they're running off engine-api master, but not docker/docker master.

See also #255.