### PR TITLE
Add a version check on client error handling

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/engine-api/client/transport/cancellable"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/versions"
 	"golang.org/x/net/context"
 )
 
@@ -133,7 +134,8 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 		}
 
 		var errorMessage string
-		if resp.Header.Get("Content-Type") == "application/json" {
+		if (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) &&
+			resp.Header.Get("Content-Type") == "application/json" {
 			var errorResponse types.ErrorResponse
 			if err := json.Unmarshal(body, &errorResponse); err != nil {
 				return serverResp, fmt.Errorf("Error reading JSON: %v", err)


### PR DESCRIPTION
In case the daemon API is older than 1.24 but the response has a content-type of `application/json`, this make sure it's keeping the old behavior before 1.24.

This is more of a "*better safe than sorry*" PR 🐮.

/cc @MHBauer @thaJeztah @calavera @bfirsh @icecrime @stevvooe 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>