### PR TITLE
Fix TestNewEnvClient with default version

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,7 +22,7 @@ func TestNewEnvClient(t *testing.T) {
 	}{
 		{
 			envs:            map[string]string{},
-			expectedVersion: "",
+			expectedVersion: DefaultVersion,
 		},
 		{
 			envs: map[string]string{
@@ -34,7 +34,7 @@ func TestNewEnvClient(t *testing.T) {
 			envs: map[string]string{
 				"DOCKER_CERT_PATH": "testdata/",
 			},
-			expectedVersion: "",
+			expectedVersion: DefaultVersion,
 		},
 		{
 			envs: map[string]string{
@@ -46,7 +46,7 @@ func TestNewEnvClient(t *testing.T) {
 			envs: map[string]string{
 				"DOCKER_HOST": "invalid://url",
 			},
-			expectedVersion: "",
+			expectedVersion: DefaultVersion,
 		},
 		{
 			envs: map[string]string{


### PR DESCRIPTION
Master *tests* got broken, did not have time to update #252 according to the default version changes in #264 :sweat_smile: 🐹.

@calavera was too fast :angel: 

/cc @calavera @thaJeztah @cpuguy83 @MHBauer 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>