### PR TITLE
Add config parameter to change per-container stop timeout during daemon shutdown

### DIFF
--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -11,9 +11,11 @@ import (
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout time.Duration) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout *time.Duration) error {
 	query := url.Values{}
-	query.Set("t", timetypes.DurationToSecondsString(timeout))
+	if timeout != nil {
+		query.Set("t", timetypes.DurationToSecondsString(*timeout))
+	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -16,7 +16,8 @@ func TestContainerRestartError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerRestart(context.Background(), "nothing", 0*time.Second)
+	timeout := 0*time.Second
+	err := client.ContainerRestart(context.Background(), "nothing", &timeout)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -39,8 +40,8 @@ func TestContainerRestart(t *testing.T) {
 			}, nil
 		}),
 	}
-
-	err := client.ContainerRestart(context.Background(), "container_id", 100*time.Second)
+	timeout := 100*time.Second
+	err := client.ContainerRestart(context.Background(), "container_id", &timeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -10,9 +10,11 @@ import (
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout time.Duration) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
 	query := url.Values{}
-	query.Set("t", timetypes.DurationToSecondsString(timeout))
+	if timeout != nil {
+		query.Set("t", timetypes.DurationToSecondsString(*timeout))
+	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -16,7 +16,8 @@ func TestContainerStopError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerStop(context.Background(), "nothing", 0*time.Second)
+	timeout := 0*time.Second
+	err := client.ContainerStop(context.Background(), "nothing", &timeout)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -39,8 +40,8 @@ func TestContainerStop(t *testing.T) {
 			}, nil
 		}),
 	}
-
-	err := client.ContainerStop(context.Background(), "container_id", 100*time.Second)
+	timeout := 100*time.Second
+	err := client.ContainerStop(context.Background(), "container_id", &timeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -38,11 +38,11 @@ type APIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout time.Duration) error
+	ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
-	ContainerStop(ctx context.Context, container string, timeout time.Duration) error
+	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error


### PR DESCRIPTION
This fix tries to add config paramter to change per-contaienr stop timeout during the daemon shutdown. As the part of the update, this fix also changes `docker restart` and `docker stop` so that if `--time` is not specified, then the default stop timeout (10s) will be used.

This fix is related to
https://github.com/docker/docker/pull/22566
https://github.com/docker/docker/issues/22471

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>