### PR TITLE
Add live restore to Info struct

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -256,6 +256,7 @@ type Info struct {
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
 	Swarm              swarm.Info
+	LiveRestore        bool
 }
 
 // PluginsInfo is a temp struct holding Plugins name


### PR DESCRIPTION
This allows some validation during swarm init (see https://github.com/docker/docker/pull/23524 for details) and would allow the --live-restore option to be shown in the `docker info` o/p.

Signed-off-by: Alessandro Boch <aboch@docker.com>