### PR TITLE
add omitempty to storageopts

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -303,7 +303,7 @@ type HostConfig struct {
 	PublishAllPorts bool              // Should docker publish all exposed port for the container
 	ReadonlyRootfs  bool              // Is the container root filesystem in read-only
 	SecurityOpt     []string          // List of string values to customize labels for MLS systems, such as SELinux.
-	StorageOpt      map[string]string // Storage driver options per container.
+	StorageOpt      map[string]string `json:",omitempty"` // Storage driver options per container.
 	Tmpfs           map[string]string `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container


### PR DESCRIPTION
https://github.com/docker/engine-api/pull/151 broke backward compat, since `StorageOpt` is unused most of a time, let's put an `omitempty` to prevent unmarshalling error.

ping @alexmavr