### PR TITLE
Update PluginInstall signature for consistency

### DIFF
--- a/client/interface_experimental.go
+++ b/client/interface_experimental.go
@@ -3,8 +3,6 @@
 package client
 
 import (
-	"io"
-
 	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
@@ -16,7 +14,7 @@ type APIClient interface {
 	PluginRemove(ctx context.Context, name string) error
 	PluginEnable(ctx context.Context, name string) error
 	PluginDisable(ctx context.Context, name string) error
-	PluginInstall(ctx context.Context, name, registryAuth string, acceptAllPermissions, noEnable bool, in io.ReadCloser, out io.Writer) error
+	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) error
 	PluginPush(ctx context.Context, name string, registryAuth string) error
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspect(ctx context.Context, name string) (*types.Plugin, error)

--- a/types/plugin.go
+++ b/types/plugin.go
@@ -7,6 +7,15 @@ import (
 	"fmt"
 )
 
+// PluginInstallOptions holds parameters to install a plugin.
+type PluginInstallOptions struct {
+	Disabled              bool
+	AcceptAllPermissions  bool
+	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
+	PrivilegeFunc         RequestPrivilegeFunc
+	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
+}
+
 // PluginConfig represents the values of settings potentially modifiable by a user
 type PluginConfig struct {
 	Mounts  []PluginMount


### PR DESCRIPTION
This make PluginInstall a little bit more consistent with the rest of the api code base 🐮:

- Make `enable` and `acceptAllPermissions` optional
- Adds `PrivilegeFunc` to make it ask for login if the daemon error is an   HTTP Unauthorized (just like image pull/push).
- Add a `AcceptPermissionsFunc` and remove Reader/Writer from the   signature. The idea is to not force interactive input/output and let   the user of the API defines the behavior for accepting permissions.

/cc @thaJeztah @runcom @tiborvass @calavera @stevvooe @icecrime 

Related PR : https://github.com/docker/docker/issues/23570

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>