### PR TITLE
Passing headers for service create/update

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -100,11 +100,11 @@ type NodeAPIClient interface {
 
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
-	ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error)
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, headers map[string][]string) (types.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
-	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, headers map[string][]string) error
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 }

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -9,9 +9,9 @@ import (
 )
 
 // ServiceCreate creates a new Service.
-func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error) {
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, headers map[string][]string) (types.ServiceCreateResponse, error) {
 	var response types.ServiceCreateResponse
-	resp, err := cli.post(ctx, "/services/create", nil, service, nil)
+	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
 	if err != nil {
 		return response, err
 	}

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -18,7 +18,7 @@ func TestServiceCreateError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{})
+	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, nil)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -47,7 +47,7 @@ func TestServiceCreate(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{})
+	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -9,10 +9,10 @@ import (
 )
 
 // ServiceUpdate updates a Service.
-func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error {
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, headers map[string][]string) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, nil)
+	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -18,7 +18,7 @@ func TestServiceUpdateError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{})
+	err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, nil)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -68,7 +68,7 @@ func TestServiceUpdate(t *testing.T) {
 			}),
 		}
 
-		err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{})
+		err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Currently, it is not possible to create or update services that require pulling of private images. This is a temporary fix to enable passing an auth token to SwarmKit from Docker. The token is retrieved at the client, and passed through as an `x-registry-auth` header which is then retrieved and added to `ContainerSpec` just before making a call to SwarmKit.

`engine-api` is in the call path, and needs to pass headers appropriately. Also see https://github.com/docker/docker/pull/23584

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>