### PR TITLE
Modify `ServiceInspect` to return raw data

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -101,7 +101,7 @@ type NodeAPIClient interface {
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
 	ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error)
-	ServiceInspect(ctx context.Context, serviceID string) (swarm.Service, error)
+	ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
 	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -18,7 +18,7 @@ func TestServiceInspectError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ServiceInspect(context.Background(), "nothing")
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing")
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -29,7 +29,7 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, err := client.ServiceInspect(context.Background(), "unknown")
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown")
 	if err == nil || !IsErrServiceNotFound(err) {
 		t.Fatalf("expected an serviceNotFoundError error, got %v", err)
 	}
@@ -55,7 +55,7 @@ func TestServiceInspect(t *testing.T) {
 		}),
 	}
 
-	serviceInspect, err := client.ServiceInspect(context.Background(), "service_id")
+	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Modify `ServiceInspect` to `ServiceInspectWithRaw`, and have it returned
the raw bytes.

Signed-off-by: Arnaud Porterie (icecrime) <arnaud.porterie@docker.com>