### PR TITLE
Improve & cleanup documentation comments

### DIFF
--- a/types/client.go
+++ b/types/client.go
@@ -12,88 +12,88 @@ import (
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
 type CheckpointCreateOptions struct {
-	CheckpointID string
-	Exit         bool
+	CheckpointID string // ID of the created checkpoint
+	Exit         bool   // Whether to exit the container after the checkpoint was was successfully created
 }
 
 // ContainerAttachOptions holds parameters to attach to a container.
 type ContainerAttachOptions struct {
-	Stream     bool
-	Stdin      bool
-	Stdout     bool
-	Stderr     bool
-	DetachKeys string
+	Stream     bool   // If true stream log output and allow input via stdin
+	Stdin      bool   // Attach to standard input, enables user interaction
+	Stdout     bool   // Attach to standard output
+	Stderr     bool   // Attach to standard error
+	DetachKeys string // Escape keys for detach
 }
 
-// ContainerCommitOptions holds parameters to commit changes into a container.
+// ContainerCommitOptions holds parameters to commit changes of a container.
 type ContainerCommitOptions struct {
-	Reference string
-	Comment   string
-	Author    string
-	Changes   []string
-	Pause     bool
-	Config    *container.Config
+	Pause     bool              // Pause container during commit
+	Reference string            // Repository (and optionally tag) for the new image
+	Author    string            // Author of the new image
+	Comment   string            // Comment for the new image
+	Changes   []string          // Dockerfile instructions to apply while committing
+	Config    *container.Config // Container configuration for the new image
 }
 
 // ContainerExecInspect holds information returned by exec inspect.
 type ContainerExecInspect struct {
-	ExecID      string
-	ContainerID string
-	Running     bool
-	ExitCode    int
+	ExecID      string // ID of the exec instance
+	ContainerID string // ID of the container
+	Running     bool   // Whether the exec'ed process is running
+	ExitCode    int    // Exit code of the exec'ed process
 }
 
 // ContainerListOptions holds parameters to list containers with.
 type ContainerListOptions struct {
-	Quiet  bool
-	Size   bool
-	All    bool
-	Latest bool
-	Since  string
-	Before string
-	Limit  int
-	Filter filters.Args
+	Quiet  bool         // Only display numeric container IDs
+	Size   bool         // Show container sizes in the output
+	All    bool         // Also show non-running containers
+	Latest bool         // Show recently created containers (including non-running ones)
+	Since  string       // Only show containers created since ID (including non-running ones)
+	Before string       // Only show containers created before ID (including non-running ones)
+	Limit  int          // Show at most N recently created containers (including non-running ones)
+	Filter filters.Args // Filter output based on these criteria
 }
 
 // ContainerLogsOptions holds parameters to filter logs with.
 type ContainerLogsOptions struct {
-	ShowStdout bool
-	ShowStderr bool
-	Since      string
-	Timestamps bool
-	Follow     bool
-	Tail       string
-	Details    bool
+	Follow     bool   // If true stream log output
+	ShowStdout bool   // Whether or not to show stdout output in addition to log entries
+	ShowStderr bool   // Whether or not to show stderr output in addition to log entries
+	Timestamps bool   // If true include timestamps for each line of log output
+	Details    bool   // If true include extra details provided to logs
+	Tail       string // Return that many lines of log output from the end
+	Since      string // Filter logs by returning only entries after this time
 }
 
 // ContainerRemoveOptions holds parameters to remove containers.
 type ContainerRemoveOptions struct {
-	RemoveVolumes bool
-	RemoveLinks   bool
-	Force         bool
+	RemoveVolumes bool // Whether to remove the volumes associated with the container
+	RemoveLinks   bool // Whether to remove the link with the specified name, instead of removing a container with that name
+	Force         bool // Whether to kill the container if it is running, instead of not removing it
 }
 
 // ContainerStartOptions holds parameters to start containers.
 type ContainerStartOptions struct {
-	CheckpointID string
+	CheckpointID string // Checkpoint to start the container from
 }
 
 // CopyToContainerOptions holds information
 // about files to copy into a container
 type CopyToContainerOptions struct {
-	AllowOverwriteDirWithFile bool
+	AllowOverwriteDirWithFile bool // Allow overwriting an existing directory with a non-directory and vice versa
 }
 
 // EventsOptions hold parameters to filter events with.
 type EventsOptions struct {
-	Since   string
-	Until   string
-	Filters filters.Args
+	Since   string       // Only show events created since this timestamp
+	Until   string       // Stream events until this timestamp
+	Filters filters.Args // Filter output based on these criteria
 }
 
 // NetworkListOptions holds parameters to filter the list of networks with.
 type NetworkListOptions struct {
-	Filters filters.Args
+	Filters filters.Args // Filter output based on these criteria
 }
 
 // HijackedResponse holds connection information for a hijacked request.
@@ -149,87 +149,85 @@ type ImageBuildOptions struct {
 	Labels         map[string]string
 }
 
-// ImageBuildResponse holds information
-// returned by a server after building
-// an image.
+// ImageBuildResponse holds information returned by a server after building an image.
 type ImageBuildResponse struct {
-	Body   io.ReadCloser
-	OSType string
+	Body   io.ReadCloser // Body must be closed to avoid a resource leak
+	OSType string        // Operating system type of the Docker daemon
 }
 
 // ImageCreateOptions holds information to create images.
 type ImageCreateOptions struct {
-	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+	RegistryAuth string // Registry credentials to be used (as base64 encoded JSON)
 }
 
-// ImageImportSource holds source information for ImageImport
+// ImageImportSource holds source information for ImageImport.
 type ImageImportSource struct {
-	Source     io.Reader // Source is the data to send to the server to create this image from (mutually exclusive with SourceName)
-	SourceName string    // SourceName is the name of the image to pull (mutually exclusive with Source)
+	Source     io.Reader // Data sent to the server to create the image from (mutually exclusive with SourceName)
+	SourceName string    // Name of the image to pull (mutually exclusive with Source)
 }
 
 // ImageImportOptions holds information to import images from the client host.
 type ImageImportOptions struct {
 	Tag     string   // Tag is the name to tag this image with. This attribute is deprecated.
 	Message string   // Message is the message to tag the image with
-	Changes []string // Changes are the raw changes to apply to this image
+	Changes []string // Dockerfile instructions to apply while importing
 }
 
 // ImageListOptions holds parameters to filter the list of images with.
 type ImageListOptions struct {
-	MatchName string
-	All       bool
-	Filters   filters.Args
+	MatchName string       // Only return images with matching names
+	All       bool         // Whether to include intermediate (i.e. untagged) images in the output
+	Filters   filters.Args // Filter output based on these criteria
 }
 
 // ImageLoadResponse returns information to the client about a load process.
 type ImageLoadResponse struct {
-	// Body must be closed to avoid a resource leak
-	Body io.ReadCloser
-	JSON bool
+	Body io.ReadCloser // Body must be closed to avoid a resource leak
+	JSON bool          // Whether the response body contains JSON instead of plain text
 }
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {
-	All           bool
-	RegistryAuth  string // RegistryAuth is the base64 encoded credentials for the registry
-	PrivilegeFunc RequestPrivilegeFunc
+	// Pull all tags from the specified repository,
+	// even if a repository:tag combination is specified
+	All bool
+
+	RegistryAuth  string               // Registry credentials to be used (as base64 encoded JSON)
+	PrivilegeFunc RequestPrivilegeFunc // Function to request alternative registry credentials
 }
 
-// RequestPrivilegeFunc is a function interface that
-// clients can supply to retry operations after
-// getting an authorization error.
-// This function returns the registry authentication
-// header value in base 64 format, or an error
-// if the privilege request fails.
-type RequestPrivilegeFunc func() (string, error)
-
-//ImagePushOptions holds information to push images.
+// ImagePushOptions holds information to push images.
 type ImagePushOptions ImagePullOptions
+
+// RequestPrivilegeFunc is a function interface that clients can
+// supply to retry operations after getting an authorization error.
+//
+// This function returns the new registry authentication header value
+// in Base64 format, or an error if the privilege request fails.
+type RequestPrivilegeFunc func() (string, error)
 
 // ImageRemoveOptions holds parameters to remove images.
 type ImageRemoveOptions struct {
-	Force         bool
-	PruneChildren bool
+	Force         bool // Also remove all tags referencing the image, instead of failing when such tags exist
+	PruneChildren bool // Also remove all untagged parents of the image
 }
 
 // ImageSearchOptions holds parameters to search images with.
 type ImageSearchOptions struct {
-	RegistryAuth  string
-	PrivilegeFunc RequestPrivilegeFunc
-	Filters       filters.Args
-	Limit         int
+	RegistryAuth  string               // Registry credentials to be used (as base64 encoded JSON)
+	PrivilegeFunc RequestPrivilegeFunc // Function to request alternative registry credentials
+	Limit         int                  // Maximum number of search results
+	Filters       filters.Args         // Filter output based on these criteria
 }
 
-// ResizeOptions holds parameters to resize a tty.
-// It can be used to resize container ttys and
-// exec process ttys too.
+// ResizeOptions holds parameters to resize a TTY.
+// It can be used to resize container TTYs and exec process TTYs too.
 type ResizeOptions struct {
 	Height int
 	Width  int
 }
 
-// VersionResponse holds version information for the client and the server
+// VersionResponse holds version information for the client and the server.
 type VersionResponse struct {
 	Client *Version
 	Server *Version
@@ -241,24 +239,23 @@ func (v VersionResponse) ServerOK() bool {
 	return v.Server != nil
 }
 
-// NodeListOptions holds parameters to list  nodes with.
+// NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
-	Filter filters.Args
+	Filter filters.Args // Filter output based on these criteria
 }
 
 // ServiceCreateResponse contains the information returned to a client
 // on the  creation of a new service.
 type ServiceCreateResponse struct {
-	// ID is the ID of the created service.
-	ID string
+	ID string // ID of the created service
 }
 
-// ServiceListOptions holds parameters to list  services with.
+// ServiceListOptions holds parameters to list services with.
 type ServiceListOptions struct {
-	Filter filters.Args
+	Filter filters.Args // Filter output based on these criteria
 }
 
-// TaskListOptions holds parameters to list  tasks with.
+// TaskListOptions holds parameters to list tasks with.
 type TaskListOptions struct {
-	Filter filters.Args
+	Filter filters.Args // Filter output based on these criteria
 }

--- a/types/client.go
+++ b/types/client.go
@@ -1,9 +1,7 @@
 package types
 
 import (
-	"bufio"
 	"io"
-	"net"
 
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
@@ -94,31 +92,6 @@ type EventsOptions struct {
 // NetworkListOptions holds parameters to filter the list of networks with.
 type NetworkListOptions struct {
 	Filters filters.Args // Filter output based on these criteria
-}
-
-// HijackedResponse holds connection information for a hijacked request.
-type HijackedResponse struct {
-	Conn   net.Conn
-	Reader *bufio.Reader
-}
-
-// Close closes the hijacked connection and reader.
-func (h *HijackedResponse) Close() {
-	h.Conn.Close()
-}
-
-// CloseWriter is an interface that implements structs
-// that close input streams to prevent from writing.
-type CloseWriter interface {
-	CloseWrite() error
-}
-
-// CloseWrite closes a readWriter for writing.
-func (h *HijackedResponse) CloseWrite() error {
-	if conn, ok := h.Conn.(CloseWriter); ok {
-		return conn.CloseWrite()
-	}
-	return nil
 }
 
 // ImageBuildOptions holds the information

--- a/types/configs.go
+++ b/types/configs.go
@@ -18,9 +18,8 @@ type ContainerCreateConfig struct {
 	AdjustCPUShares  bool
 }
 
-// ContainerRmConfig holds arguments for the container remove
-// operation. This struct is used to tell the backend what operations
-// to perform.
+// ContainerRmConfig holds arguments for the container remove operation.
+// This struct is used to tell the backend what operations to perform.
 type ContainerRmConfig struct {
 	ForceRemove, RemoveVolume, RemoveLink bool
 }
@@ -28,26 +27,25 @@ type ContainerRmConfig struct {
 // ContainerCommitConfig contains build configs for commit operation,
 // and is used when making a commit with the current state of the container.
 type ContainerCommitConfig struct {
-	Pause   bool
-	Repo    string
-	Tag     string
-	Author  string
-	Comment string
-	// merge container config into commit config before commit
-	MergeConfigs bool
-	Config       *container.Config
+	Pause        bool              // Pause container during commit
+	Repo         string            // Repository name of the new image
+	Tag          string            // Tag name of the new image
+	Author       string            // Author of the new image
+	Comment      string            // Comment for the new image
+	MergeConfigs bool              // Merge container config into commit config before commit
+	Config       *container.Config // Container configuration for the new image
 }
 
-// ExecConfig is a small subset of the Config struct that holds the configuration
-// for the exec feature of docker.
+// ExecConfig is a small subset of the Config struct that
+// holds the configuration for the exec feature of docker.
 type ExecConfig struct {
 	User         string   // User that will run the command
-	Privileged   bool     // Is the container in privileged mode
-	Tty          bool     // Attach standard streams to a tty.
-	AttachStdin  bool     // Attach the standard input, makes possible user interaction
-	AttachStderr bool     // Attach the standard output
-	AttachStdout bool     // Attach the standard error
-	Detach       bool     // Execute in detach mode
+	Privileged   bool     // Run the command in privileged mode
+	Tty          bool     // Attach standard streams to a tty
+	AttachStdin  bool     // Attach the standard input, enables user interaction
+	AttachStdout bool     // Attach the standard output
+	AttachStderr bool     // Attach the standard error
+	Detach       bool     // Execute in detached mode
 	DetachKeys   string   // Escape keys for detach
 	Cmd          []string // Execution commands and args
 }

--- a/types/io.go
+++ b/types/io.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"bufio"
+	"net"
+)
+
+// HijackedResponse holds connection information for a hijacked request.
+type HijackedResponse struct {
+	Conn   net.Conn
+	Reader *bufio.Reader
+}
+
+// Close closes the hijacked connection and reader.
+func (h *HijackedResponse) Close() {
+	h.Conn.Close()
+}
+
+// CloseWriter is an interface that implements structs
+// that close input streams to prevent from writing.
+type CloseWriter interface {
+	CloseWrite() error
+}
+
+// CloseWrite closes a readWriter for writing.
+func (h *HijackedResponse) CloseWrite() error {
+	if conn, ok := h.Conn.(CloseWriter); ok {
+		return conn.CloseWrite()
+	}
+	return nil
+}

--- a/types/plugin.go
+++ b/types/plugin.go
@@ -9,32 +9,37 @@ import (
 
 // PluginInstallOptions holds parameters to install a plugin.
 type PluginInstallOptions struct {
-	Disabled              bool
-	AcceptAllPermissions  bool
-	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
-	PrivilegeFunc         RequestPrivilegeFunc
+	Disabled             bool                 // Do not enable the plugin on install
+	AcceptAllPermissions bool                 // Grant all permissions requested by the plugin
+	RegistryAuth         string               // Registry credentials to be used (as base64 encoded JSON)
+	PrivilegeFunc        RequestPrivilegeFunc // Function to request alternative registry credentials
+	// AcceptPermissionFunc is passed the list of privileges
+	// requested by the plugin, and has to decide whether
+	// or not the requested privileges will be granted.
 	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
 }
 
-// PluginConfig represents the values of settings potentially modifiable by a user
+// PluginConfig represents the values of settings which are potentially modifiable by a user.
 type PluginConfig struct {
-	Mounts  []PluginMount
-	Env     []string
-	Args    []string
-	Devices []PluginDevice
+	Mounts  []PluginMount  // List of configured volumes
+	Env     []string       // List of configured environment variables
+	Args    []string       // List of configured command line arguments
+	Devices []PluginDevice // List of configured devices
 }
 
-// Plugin represents a Docker plugin for the remote API
+// Plugin represents a Docker plugin for the remote API.
 type Plugin struct {
-	ID       string `json:"Id,omitempty"`
-	Name     string
-	Tag      string
-	Active   bool
-	Config   PluginConfig
-	Manifest PluginManifest
+	// ID of the plugin.
+	ID string `json:"Id,omitempty"`
+
+	Name     string         // Name of the plugin
+	Tag      string         // Tag of the plugin
+	Active   bool           // Whether the plugin is currently enabled
+	Config   PluginConfig   // Runtime configuration of the plugin
+	Manifest PluginManifest // Manifest of the plugin
 }
 
-// PluginsListResponse contains the response for the remote API
+// PluginsListResponse represents a list of plugins.
 type PluginsListResponse []*Plugin
 
 const (
@@ -48,11 +53,11 @@ const (
 // PluginInterfaceType represents a type that a plugin implements.
 type PluginInterfaceType struct {
 	Prefix     string // This is always "docker"
-	Capability string // Capability should be validated against the above list.
-	Version    string // Plugin API version. Depends on the capability
+	Capability string // Capability that specifies the interface that is supported (e.g. "network")
+	Version    string // Plugin API version. Depends on the capability.
 }
 
-// UnmarshalJSON implements json.Unmarshaler for PluginInterfaceType
+// UnmarshalJSON implements json.Unmarshaler for PluginInterfaceType.
 func (t *PluginInterfaceType) UnmarshalJSON(p []byte) error {
 	versionIndex := len(p)
 	prefixIndex := 0
@@ -78,7 +83,7 @@ loop:
 	return nil
 }
 
-// MarshalJSON implements json.Marshaler for PluginInterfaceType
+// MarshalJSON implements json.Marshaler for PluginInterfaceType.
 func (t *PluginInterfaceType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.String())
 }
@@ -90,80 +95,80 @@ func (t PluginInterfaceType) String() string {
 
 // PluginInterface describes the interface between Docker and plugin
 type PluginInterface struct {
-	Types  []PluginInterfaceType
-	Socket string
+	Types  []PluginInterfaceType // Interfaces used for communication between Docker and plugin
+	Socket string                // Socket used for communication between Docker and plugin
 }
 
-// PluginSetting is to be embedded in other structs, if they are supposed to be
-// modifiable by the user.
+// PluginSetting is to be embedded in other structs,
+// if they are supposed to be modifiable by the user.
 type PluginSetting struct {
-	Name        string
-	Description string
-	Settable    []string
+	Name        string   // Name of the associated configuration variable
+	Description string   // Description of the associated configuration variable
+	Settable    []string // List of fields that are settable by the user
 }
 
-// PluginNetwork represents the network configuration for a plugin
+// PluginNetwork represents the network configuration for a plugin.
 type PluginNetwork struct {
 	Type string
 }
 
-// PluginMount represents the mount configuration for a plugin
+// PluginMount represents the mount configuration for a plugin.
 type PluginMount struct {
 	PluginSetting
-	Source      *string
-	Destination string
-	Type        string
-	Options     []string
+	Source      *string  // Source path of the mount
+	Destination string   // Destination path of the mount inside the container
+	Type        string   // Kind of the mount (e.g. "bind")
+	Options     []string // Mount options (fstab style options)
 }
 
-// PluginEnv represents an environment variable for a plugin
+// PluginEnv represents an environment variable for a plugin.
 type PluginEnv struct {
-	PluginSetting
-	Value *string
+	PluginSetting         // Name of the environment variable is specified by PluginSettings.Name
+	Value         *string // Value of the environment variable
 }
 
-// PluginArgs represents the command line arguments for a plugin
+// PluginArgs represents the command line arguments for a plugin.
 type PluginArgs struct {
 	PluginSetting
-	Value []string
+	Value []string // List of command line arguments for the plugin
 }
 
-// PluginDevice represents a device for a plugin
+// PluginDevice represents a host device to be mounted for a plugin.
 type PluginDevice struct {
 	PluginSetting
-	Path *string
+	Path *string // File path of the host device
 }
 
-// PluginUser represents the user for the plugin's process
+// PluginUser represents the user for the plugin's process.
 type PluginUser struct {
-	UID uint32 `json:"Uid,omitempty"`
-	GID uint32 `json:"Gid,omitempty"`
+	UID uint32 `json:"Uid,omitempty"` // User ID of the plugin process
+	GID uint32 `json:"Gid,omitempty"` // Group ID of the plugin process
 }
 
-// PluginManifest represents the manifest of a plugin
+// PluginManifest represents the manifest of a plugin.
 type PluginManifest struct {
-	ManifestVersion string
-	Description     string
-	Documentation   string
-	Interface       PluginInterface
-	Entrypoint      []string
-	Workdir         string
-	User            PluginUser `json:",omitempty"`
-	Network         PluginNetwork
-	Capabilities    []string
-	Mounts          []PluginMount
-	Devices         []PluginDevice
-	Env             []PluginEnv
-	Args            PluginArgs
+	ManifestVersion string          // Schema version of the manifest
+	Description     string          // Description of the plugin
+	Documentation   string          // Documentation for the plugins
+	Interface       PluginInterface // Interfaces supported by the plugin
+	Entrypoint      []string        // Default entrypoint executable and arguments
+	Workdir         string          // Default working directory
+	User            PluginUser      `json:",omitempty"`
+	Network         PluginNetwork   // Default network configuration
+	Capabilities    []string        // Capabilities supported by the plugin
+	Mounts          []PluginMount   // List of default mounts
+	Devices         []PluginDevice  // List of host devices to mount by default
+	Env             []PluginEnv     // List of default environment variables
+	Args            PluginArgs      // List of default plugin arguments
 }
 
-// PluginPrivilege describes a permission the user has to accept
-// upon installing a plugin.
+// PluginPrivilege describes a permission the user
+// has to accept upon installing a plugin.
 type PluginPrivilege struct {
-	Name        string
-	Description string
-	Value       []string
+	Name        string   // Name of the requested privilege (e.g. "network", "device")
+	Description string   // Description of the requested privilege
+	Value       []string // Further specification of the requested privilege (e.g. path of device)
 }
 
-// PluginPrivileges is a list of PluginPrivilege
+// PluginPrivileges represents a list of plugin privileges.
 type PluginPrivileges []PluginPrivilege

--- a/types/seccomp.go
+++ b/types/seccomp.go
@@ -10,8 +10,8 @@ type Seccomp struct {
 // Arch used for additional architectures
 type Arch string
 
-// Additional architectures permitted to be used for system calls
-// By default only the native architecture of the kernel is permitted
+// Additional architectures permitted to be used for system calls.
+// By default only the native architecture of the kernel is permitted.
 const (
 	ArchX86         Arch = "SCMP_ARCH_X86"
 	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
@@ -31,10 +31,10 @@ const (
 	ArchS390X       Arch = "SCMP_ARCH_S390X"
 )
 
-// Action taken upon Seccomp rule match
+// Action taken upon Seccomp rule match.
 type Action string
 
-// Define actions for Seccomp rules
+// Define actions for Seccomp rules.
 const (
 	ActKill  Action = "SCMP_ACT_KILL"
 	ActTrap  Action = "SCMP_ACT_TRAP"
@@ -46,7 +46,7 @@ const (
 // Operator used to match syscall arguments in Seccomp
 type Operator string
 
-// Define operators for syscall arguments in Seccomp
+// Define operators for syscall arguments in Seccomp.
 const (
 	OpNotEqual     Operator = "SCMP_CMP_NE"
 	OpLessThan     Operator = "SCMP_CMP_LT"
@@ -57,7 +57,7 @@ const (
 	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
 )
 
-// Arg used for matching specific syscall arguments in Seccomp
+// Arg used for matching specific syscall arguments in Seccomp.
 type Arg struct {
 	Index    uint     `json:"index"`
 	Value    uint64   `json:"value"`
@@ -65,7 +65,7 @@ type Arg struct {
 	Op       Operator `json:"op"`
 }
 
-// Syscall is used to match a syscall in Seccomp
+// Syscall is used to match a syscall in Seccomp.
 type Syscall struct {
 	Name   string `json:"name"`
 	Action Action `json:"action"`

--- a/types/stats.go
+++ b/types/stats.go
@@ -4,51 +4,36 @@ package types
 
 import "time"
 
-// ThrottlingData stores CPU throttling stats of one running container
+// ThrottlingData stores the CPU throttling stats of one running container.
 type ThrottlingData struct {
-	// Number of periods with throttling active
-	Periods uint64 `json:"periods"`
-	// Number of periods when the container hits its throttling limit.
-	ThrottledPeriods uint64 `json:"throttled_periods"`
-	// Aggregate time the container was throttled for in nanoseconds.
-	ThrottledTime uint64 `json:"throttled_time"`
+	Periods          uint64 `json:"periods"`           // Number of periods with throttling active
+	ThrottledPeriods uint64 `json:"throttled_periods"` // Number of periods where the container hit its throttling limit
+	ThrottledTime    uint64 `json:"throttled_time"`    // Aggregate time the container was throttled for in nanoseconds
 }
 
-// CPUUsage stores All CPU stats aggregated since container inception.
+// CPUUsage stores all CPU stats aggregated since the container was created.
 type CPUUsage struct {
-	// Total CPU time consumed.
-	// Units: nanoseconds.
-	TotalUsage uint64 `json:"total_usage"`
-	// Total CPU time consumed per core.
-	// Units: nanoseconds.
-	PercpuUsage []uint64 `json:"percpu_usage"`
-	// Time spent by tasks of the cgroup in kernel mode.
-	// Units: nanoseconds.
-	UsageInKernelmode uint64 `json:"usage_in_kernelmode"`
-	// Time spent by tasks of the cgroup in user mode.
-	// Units: nanoseconds.
-	UsageInUsermode uint64 `json:"usage_in_usermode"`
+	TotalUsage        uint64   `json:"total_usage"`         // Total CPU time consumed (in nanoseconds)
+	PercpuUsage       []uint64 `json:"percpu_usage"`        // Total CPU time consumed per core (in nanoseconds)
+	UsageInKernelmode uint64   `json:"usage_in_kernelmode"` // Time spent by tasks of the cgroup in kernel mode (in nanoseconds)
+	UsageInUsermode   uint64   `json:"usage_in_usermode"`   // Time spent by tasks of the cgroup in user mode (in seconds)
 }
 
-// CPUStats aggregates and wraps all CPU related info of container
+// CPUStats aggregates and wraps all CPU related info of a container.
 type CPUStats struct {
 	CPUUsage       CPUUsage       `json:"cpu_usage"`
 	SystemUsage    uint64         `json:"system_cpu_usage"`
 	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
 }
 
-// MemoryStats aggregates All memory stats since container inception
+// MemoryStats aggregates all memory stats since the container was created.
 type MemoryStats struct {
-	// current res_counter usage for memory
-	Usage uint64 `json:"usage"`
-	// maximum usage ever recorded.
-	MaxUsage uint64 `json:"max_usage"`
+	Usage    uint64 `json:"usage"`     // Current memory usage of the container
+	MaxUsage uint64 `json:"max_usage"` // Maximum memory usage of the container since it was created
 	// TODO(vishh): Export these as stronger types.
-	// all the stats exported via memory.stat.
-	Stats map[string]uint64 `json:"stats"`
-	// number of times memory usage hits limits.
-	Failcnt uint64 `json:"failcnt"`
-	Limit   uint64 `json:"limit"`
+	Stats   map[string]uint64 `json:"stats"`   // All stats exported via memory.stat
+	Failcnt uint64            `json:"failcnt"` // Number of times when memory usage hit limits
+	Limit   uint64            `json:"limit"`   // Maximum allowed memory usage configured for the container
 }
 
 // BlkioStatEntry is one small entity to store a piece of Blkio stats
@@ -60,10 +45,10 @@ type BlkioStatEntry struct {
 	Value uint64 `json:"value"`
 }
 
-// BlkioStats stores All IO service stats for data read and write
+// BlkioStats stores all IO service stats for data read and write.
 // TODO Windows: This can be factored out
 type BlkioStats struct {
-	// number of bytes transferred to and from the block device
+	// Number of bytes transferred to and from the block device
 	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive"`
 	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recursive"`
 	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive"`
@@ -74,7 +59,7 @@ type BlkioStats struct {
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive"`
 }
 
-// NetworkStats aggregates All network stats of one container
+// NetworkStats aggregates all network stats of a container.
 // TODO Windows: This will require refactoring
 type NetworkStats struct {
 	RxBytes   uint64 `json:"rx_bytes"`
@@ -87,16 +72,17 @@ type NetworkStats struct {
 	TxDropped uint64 `json:"tx_dropped"`
 }
 
-// PidsStats contains the stats of a container's pids
+// PidsStats contains the stats of a container's pids.
 type PidsStats struct {
-	// Current is the number of pids in the cgroup
+	// Current is the number of pids in the cgroup.
 	Current uint64 `json:"current,omitempty"`
+
 	// Limit is the hard limit on the number of pids in the cgroup.
 	// A "Limit" of 0 means that there is no limit.
 	Limit uint64 `json:"limit,omitempty"`
 }
 
-// Stats is Ultimate struct aggregating all types of stats of one container
+// Stats is the ultimate struct aggregating all types of stats of one container.
 type Stats struct {
 	Read        time.Time   `json:"read"`
 	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"`

--- a/types/types.go
+++ b/types/types.go
@@ -11,32 +11,30 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-// ContainerCreateResponse contains the information returned to a client on the
-// creation of a new container.
+// ContainerCreateResponse contains the information returned
+// to a client on the creation of a new container.
 type ContainerCreateResponse struct {
-	// ID is the ID of the created container.
-	ID string `json:"Id"`
-
-	// Warnings are any warnings encountered during the creation of the container.
-	Warnings []string `json:"Warnings"`
+	ID       string   `json:"Id"`       // ID of the created container.
+	Warnings []string `json:"Warnings"` // Warnings encountered during the creation of the container.
 }
 
-// ContainerExecCreateResponse contains response of Remote API:
-// POST "/containers/{name:.*}/exec"
+// ContainerExecCreateResponse contains the information
+// returned to a client on the creation of a new exec process.
 type ContainerExecCreateResponse struct {
-	// ID is the exec ID.
-	ID string `json:"Id"`
+	ID string `json:"Id"` // ID is the exec ID
 }
 
-// ContainerUpdateResponse contains response of Remote API:
-// POST "/containers/{name:.*}/update"
+// ContainerUpdateResponse contains the information returned to a client
+// after dynamically updating the configuration of a container.
 type ContainerUpdateResponse struct {
 	// Warnings are any warnings encountered during the updating of the container.
 	Warnings []string `json:"Warnings"`
 }
 
-// AuthResponse contains response of Remote API:
-// POST "/auth"
+// AuthResponse contains the information returned to a client
+// after validating the specified registry credentials.
+// If available, the response contains an identity token that
+// can be used for accessing the registry without password.
 type AuthResponse struct {
 	// Status is the authentication status
 	Status string `json:"Status"`
@@ -46,27 +44,27 @@ type AuthResponse struct {
 	IdentityToken string `json:"IdentityToken,omitempty"`
 }
 
-// ContainerWaitResponse contains response of Remote API:
-// POST "/containers/"+containerID+"/wait"
+// ContainerWaitResponse contains the information returned
+// to a client when the waited-on container has exited.
 type ContainerWaitResponse struct {
 	// StatusCode is the status code of the wait job
-	StatusCode int `json:"StatusCode"`
+	StatusCode int `json:"StatusCode"` // Exit code of the container's root process.
 }
 
-// ContainerCommitResponse contains response of Remote API:
+// ContainerCommitResponse contains the response of the Remote API:
 // POST "/commit?container="+containerID
 type ContainerCommitResponse struct {
 	ID string `json:"Id"`
 }
 
-// ContainerChange contains response of Remote API:
-// GET "/containers/{name:.*}/changes"
+// ContainerChange represents a single change to a container's filesystem.
 type ContainerChange struct {
-	Kind int
-	Path string
+	Kind int    // Kind of change (Modify=0, Add=1, Delete=2)
+	Path string // Path to changed file/directory
 }
 
-// ImageHistory contains response of Remote API:
+// ImageHistory represents the history of an image
+// that is returned to a client for the Remote API:
 // GET "/images/{name:.*}/history"
 type ImageHistory struct {
 	ID        string `json:"Id"`
@@ -77,14 +75,16 @@ type ImageHistory struct {
 	Comment   string
 }
 
-// ImageDelete contains response of Remote API:
+// ImageDelete represents a single image that was untagged or deleted.
+// It is used in the repsonse of the Remote API:
 // DELETE "/images/{name:.*}"
 type ImageDelete struct {
-	Untagged string `json:",omitempty"`
-	Deleted  string `json:",omitempty"`
+	Untagged string `json:",omitempty"` // ID of the image from which a named tag was removed (mutually exclusive with Deleted)
+	Deleted  string `json:",omitempty"` // ID of the image which has been deleted (mutually exclusive with Untagged)
 }
 
-// Image contains response of Remote API:
+// Image represents the image description that
+// is returned to a client for the Remote API:
 // GET "/images/json"
 type Image struct {
 	ID          string `json:"Id"`
@@ -97,21 +97,21 @@ type Image struct {
 	Labels      map[string]string
 }
 
-// GraphDriverData returns Image's graph driver config info
-// when calling inspect command
+// GraphDriverData represents an image's graph driver
+// config info when calling inspect command.
 type GraphDriverData struct {
 	Name string
 	Data map[string]string
 }
 
-// RootFS returns Image's RootFS description including the layer IDs.
+// RootFS returns an image's RootFS description including the layer IDs.
 type RootFS struct {
 	Type      string
 	Layers    []string `json:",omitempty"`
 	BaseLayer string   `json:",omitempty"`
 }
 
-// ImageInspect contains response of Remote API:
+// ImageInspect contains the response of the Remote API:
 // GET "/images/{name:.*}/json"
 type ImageInspect struct {
 	ID              string `json:"Id"`
@@ -133,8 +133,8 @@ type ImageInspect struct {
 	RootFS          RootFS
 }
 
-// Port stores open ports info of container
-// e.g. {"PrivatePort": 8080, "PublicPort": 80, "Type": "tcp"}
+// Port stores open ports info of a container,
+// e.g. {"PrivatePort": 8080, "PublicPort": 80, "Type": "tcp"}.
 type Port struct {
 	IP          string `json:",omitempty"`
 	PrivatePort int
@@ -142,7 +142,7 @@ type Port struct {
 	Type        string
 }
 
-// Container contains response of Remote API:
+// Container contains the response of the Remote API:
 // GET "/containers/json"
 type Container struct {
 	ID         string `json:"Id"`
@@ -170,25 +170,30 @@ type CopyConfig struct {
 	Resource string
 }
 
-// ContainerPathStat is used to encode the header from
-// GET "/containers/{name:.*}/archive"
+// ContainerPathStat is used to encode the X-Docker-Container-Path-Stat
+// header from GET "/containers/{name:.*}/archive".
 // "Name" is the file or directory name.
 type ContainerPathStat struct {
-	Name       string      `json:"name"`
-	Size       int64       `json:"size"`
-	Mode       os.FileMode `json:"mode"`
-	Mtime      time.Time   `json:"mtime"`
-	LinkTarget string      `json:"linkTarget"`
+	Name       string      `json:"name"`       // Name of the archived file or directory
+	Size       int64       `json:"size"`       // Size of the archived file or directory (before compression)
+	Mode       os.FileMode `json:"mode"`       // File mode of the archived file or directory.
+	Mtime      time.Time   `json:"mtime"`      // Modification time of the archived file or directory
+	LinkTarget string      `json:"linkTarget"` // The original link target if the targeted file was a symbolic link
 }
 
-// ContainerProcessList contains response of Remote API:
+// ContainerProcessList contains the response of the Remote API:
 // GET "/containers/{name:.*}/top"
 type ContainerProcessList struct {
+	// List of processes running in the container.
+	// Each process is represented by a nested array
+	// containing the columns specified by Titles.
 	Processes [][]string
-	Titles    []string
+
+	// Titles of the columns available for each process.
+	Titles []string
 }
 
-// Version contains response of Remote API:
+// Version contains the response of the Remote API:
 // GET "/version"
 type Version struct {
 	Version       string
@@ -202,7 +207,7 @@ type Version struct {
 	BuildTime     string `json:",omitempty"`
 }
 
-// Info contains response of Remote API:
+// Info contains the response of the Remote API:
 // GET "/info"
 type Info struct {
 	ID                 string
@@ -261,21 +266,16 @@ type Info struct {
 // PluginsInfo is a temp struct holding Plugins name
 // registered with docker daemon. It is used by Info struct
 type PluginsInfo struct {
-	// List of Volume plugins registered
-	Volume []string
-	// List of Network plugins registered
-	Network []string
-	// List of Authorization plugins registered
-	Authorization []string
+	Volume        []string // List of Volume plugins registered
+	Network       []string // List of Network plugins registered
+	Authorization []string // List of Authorization plugins registered
 }
 
 // ExecStartCheck is a temp struct used by execStart
 // Config fields is part of ExecConfig in runconfig package
 type ExecStartCheck struct {
-	// ExecStart will first check if it's detached
-	Detach bool
-	// Check if there's a tty
-	Tty bool
+	Detach bool // ExecStart will first check if it's detached
+	Tty    bool // Check if there's a tty
 }
 
 // HealthcheckResult stores information about a single run of a healthcheck probe
@@ -300,8 +300,8 @@ type Health struct {
 	Log           []*HealthcheckResult // Log contains the last few results (oldest first)
 }
 
-// ContainerState stores container's running state
-// it's part of ContainerJSONBase and will return by "inspect" command
+// ContainerState stores a container's running state. It is part of
+// ContainerJSONBase and will be returned by the "inspect" command.
 type ContainerState struct {
 	Status     string
 	Running    bool
@@ -317,8 +317,8 @@ type ContainerState struct {
 	Health     *Health `json:",omitempty"`
 }
 
-// ContainerNode stores information about the node that a container
-// is running on.  It's only available in Docker Swarm
+// ContainerNode stores information about the node that a
+// container is running on. It's only available in Docker Swarm.
 type ContainerNode struct {
 	ID        string
 	IPAddress string `json:"IP"`
@@ -329,7 +329,7 @@ type ContainerNode struct {
 	Labels    map[string]string
 }
 
-// ContainerJSONBase contains response of Remote API:
+// ContainerJSONBase contains the response of the Remote API:
 // GET "/containers/{name:.*}/json"
 type ContainerJSONBase struct {
 	ID              string `json:"Id"`
@@ -364,20 +364,21 @@ type ContainerJSON struct {
 	NetworkSettings *NetworkSettings
 }
 
-// NetworkSettings exposes the network settings in the api
+// NetworkSettings exposes the network settings of a container in the API.
 type NetworkSettings struct {
 	NetworkSettingsBase
 	DefaultNetworkSettings
 	Networks map[string]*network.EndpointSettings
 }
 
-// SummaryNetworkSettings provides a summary of container's networks
-// in /containers/json
+// SummaryNetworkSettings provides a summary of
+// a container's networks in /containers/json.
 type SummaryNetworkSettings struct {
 	Networks map[string]*network.EndpointSettings
 }
 
-// NetworkSettingsBase holds basic information about networks
+// NetworkSettingsBase holds basic information
+// about a container's connnection to a network.
 type NetworkSettingsBase struct {
 	Bridge                 string      // Bridge is the Bridge name the network uses(e.g. `docker0`)
 	SandboxID              string      // SandboxID uniquely represents a container's network stack
@@ -415,7 +416,8 @@ type MountPoint struct {
 	Propagation string
 }
 
-// Volume represents the configuration of a volume for the remote API
+// Volume represents the configuration of a volume for the Remote API:
+// GET "/volumes".
 type Volume struct {
 	Name       string                 // Name is the name of the volume
 	Driver     string                 // Driver is the Driver name used to create the volume
@@ -425,23 +427,23 @@ type Volume struct {
 	Scope      string                 // Scope describes the level at which the volume exists (e.g. `global` for cluster-wide or `local` for machine level)
 }
 
-// VolumesListResponse contains the response for the remote API:
-// GET "/volumes"
+// VolumesListResponse contains the response for the Remote API:
+// GET "/volumes".
 type VolumesListResponse struct {
 	Volumes  []*Volume // Volumes is the list of volumes being returned
 	Warnings []string  // Warnings is a list of warnings that occurred when getting the list from the volume drivers
 }
 
-// VolumeCreateRequest contains the response for the remote API:
+// VolumeCreateRequest contains the response for the Remote API:
 // POST "/volumes/create"
 type VolumeCreateRequest struct {
 	Name       string            // Name is the requested name of the volume
 	Driver     string            // Driver is the name of the driver that should be used to create the volume
-	DriverOpts map[string]string // DriverOpts holds the driver specific options to use for when creating the volume.
-	Labels     map[string]string // Labels holds metadata specific to the volume being created.
+	DriverOpts map[string]string // DriverOpts holds the driver specific options to use for when creating the volume
+	Labels     map[string]string // Labels holds metadata specific to the volume being created
 }
 
-// NetworkResource is the body of the "get network" http response message
+// NetworkResource represents the description of a network that is returned to a client.
 type NetworkResource struct {
 	Name       string                      // Name is the requested name of the network
 	ID         string                      `json:"Id"` // ID uniquely indentifies a network on a single machine
@@ -455,7 +457,7 @@ type NetworkResource struct {
 	Labels     map[string]string           // Labels holds metadata specific to the network being created
 }
 
-// EndpointResource contains network resources allocated and used for a container in a network
+// EndpointResource contains network resources allocated and used for a container in a network.
 type EndpointResource struct {
 	Name        string
 	EndpointID  string
@@ -464,7 +466,7 @@ type EndpointResource struct {
 	IPv6Address string
 }
 
-// NetworkCreate is the expected body of the "create network" http request message
+// NetworkCreate is the expected body of the "create network" http request message.
 type NetworkCreate struct {
 	CheckDuplicate bool
 	Driver         string
@@ -487,19 +489,19 @@ type NetworkCreateResponse struct {
 	Warning string
 }
 
-// NetworkConnect represents the data to be used to connect a container to the network
+// NetworkConnect represents the data to be used to connect a container to the network.
 type NetworkConnect struct {
 	Container      string
 	EndpointConfig *network.EndpointSettings `json:",omitempty"`
 }
 
-// NetworkDisconnect represents the data to be used to disconnect a container from the network
+// NetworkDisconnect represents the data to be used to disconnect a container from the network.
 type NetworkDisconnect struct {
 	Container string
 	Force     bool
 }
 
-// Checkpoint represents the details of a checkpoint
+// Checkpoint represents the details of a checkpoint.
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint
 }
@@ -508,7 +510,7 @@ type Checkpoint struct {
 // OCI runtime being shipped with the docker daemon package.
 var DefaultRuntimeName = "default"
 
-// Runtime describes an OCI runtime
+// Runtime describes an OCI runtime.
 type Runtime struct {
 	Path string   `json:"path"`
 	Args []string `json:"runtimeArgs,omitempty"`


### PR DESCRIPTION
This PR tries to improve the code documentation by:
* Adding documentation to many fields.
* Using a consistent interpunctuation (Type/Method/.. comments always end with a colon, single line field comments don't).
* Only in a few cases: Reorder struct fields to improve readability.