### PR TITLE
Delete DefaultRuntimeName variable

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -254,7 +254,6 @@ type Info struct {
 	ClusterAdvertise   string
 	SecurityOptions    []string
 	Runtimes           map[string]Runtime
-	DefaultRuntime     string
 	Swarm              swarm.Info
 }
 
@@ -503,10 +502,6 @@ type NetworkDisconnect struct {
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint
 }
-
-// DefaultRuntimeName is the reserved name/alias used to represent the
-// OCI runtime being shipped with the docker daemon package.
-var DefaultRuntimeName = "default"
 
 // Runtime describes an OCI runtime
 type Runtime struct {


### PR DESCRIPTION
It is no longer used or needed (see docker/docker#23775)

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>