### PR TITLE
Add directory as an option to checkpoint commands

### DIFF
--- a/client/checkpoint_delete.go
+++ b/client/checkpoint_delete.go
@@ -1,12 +1,20 @@
 package client
 
 import (
+	"net/url"
+
+	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
 // CheckpointDelete deletes the checkpoint with the given name from the given container
-func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, checkpointID string) error {
-	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+checkpointID, nil, nil)
+func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, options types.CheckpointDeleteOptions) error {
+	query := url.Values{}
+	if options.CheckpointDir != "" {
+		query.Set("dir", options.CheckpointDir)
+	}
+
+	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+options.CheckpointID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
@@ -16,7 +17,10 @@ func TestCheckpointDeleteError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.CheckpointDelete(context.Background(), "container_id", "checkpoint_id")
+	err := client.CheckpointDelete(context.Background(), "container_id", types.CheckpointDeleteOptions{
+		CheckpointID: "checkpoint_id",
+	})
+
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -40,7 +44,10 @@ func TestCheckpointDelete(t *testing.T) {
 		}),
 	}
 
-	err := client.CheckpointDelete(context.Background(), "container_id", "checkpoint_id")
+	err := client.CheckpointDelete(context.Background(), "container_id", types.CheckpointDeleteOptions{
+		CheckpointID: "checkpoint_id",
+	})
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -2,16 +2,22 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
 // CheckpointList returns the volumes configured in the docker host.
-func (cli *Client) CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error) {
+func (cli *Client) CheckpointList(ctx context.Context, container string, options types.CheckpointListOptions) ([]types.Checkpoint, error) {
 	var checkpoints []types.Checkpoint
 
-	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", nil, nil)
+	query := url.Values{}
+	if options.CheckpointDir != "" {
+		query.Set("dir", options.CheckpointDir)
+	}
+
+	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
 	if err != nil {
 		return checkpoints, err
 	}

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -18,7 +18,7 @@ func TestCheckpointListError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.CheckpointList(context.Background(), "container_id")
+	_, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -47,7 +47,7 @@ func TestCheckpointList(t *testing.T) {
 		}),
 	}
 
-	checkpoints, err := client.CheckpointList(context.Background(), "container_id")
+	checkpoints, err := client.CheckpointList(context.Background(), "container_id", types.CheckpointListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface_experimental.go
+++ b/client/interface_experimental.go
@@ -17,8 +17,8 @@ type APIClient interface {
 // CheckpointAPIClient defines API client methods for the checkpoints
 type CheckpointAPIClient interface {
 	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
-	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
-	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
+	CheckpointDelete(ctx context.Context, container string, options types.CheckpointDeleteOptions) error
+	CheckpointList(ctx context.Context, container string, options types.CheckpointListOptions) ([]types.Checkpoint, error)
 }
 
 // PluginAPIClient defines API client methods for the plugins

--- a/types/client.go
+++ b/types/client.go
@@ -12,8 +12,20 @@ import (
 
 // CheckpointCreateOptions holds parameters to create a checkpoint from a container
 type CheckpointCreateOptions struct {
-	CheckpointID string
-	Exit         bool
+	CheckpointID  string
+	CheckpointDir string
+	Exit          bool
+}
+
+// CheckpointListOptions holds parameters to list checkpoints for a container
+type CheckpointListOptions struct {
+	CheckpointDir string
+}
+
+// CheckpointDeleteOptions holds parameters to delete a checkpoint from a container
+type CheckpointDeleteOptions struct {
+	CheckpointID  string
+	CheckpointDir string
 }
 
 // ContainerAttachOptions holds parameters to attach to a container.
@@ -75,7 +87,8 @@ type ContainerRemoveOptions struct {
 
 // ContainerStartOptions holds parameters to start containers.
 type ContainerStartOptions struct {
-	CheckpointID string
+	CheckpointID  string
+	CheckpointDir string
 }
 
 // CopyToContainerOptions holds information


### PR DESCRIPTION
containerd provides support for providing the storage location for checkpoints, and this exposes that same support at the docker level. (This is useful when you want to create multiple containers from a single checkpoint).

Signed-off-by: Ross Boucher <rboucher@gmail.com>