### PR TITLE
Add DefaultRuntime back to info

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -254,6 +254,7 @@ type Info struct {
 	ClusterAdvertise   string
 	SecurityOptions    []string
 	Runtimes           map[string]Runtime
+	DefaultRuntime     string
 	Swarm              swarm.Info
 }
 


### PR DESCRIPTION
Seems this was not supposed to be removed with #289

@mlaventure 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>