### PR TITLE
client/services: remove header arguments from ServiceCreate, ServiceU…

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -100,11 +100,11 @@ type NodeAPIClient interface {
 
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
-	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, headers map[string][]string) (types.ServiceCreateResponse, error)
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
-	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, headers map[string][]string) error
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) error
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
 	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
 }

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -1,3 +1,5 @@
+// +build experimental
+
 package client
 
 import (

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -1,3 +1,5 @@
+// +build experimental
+
 package client
 
 import (

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -9,7 +9,15 @@ import (
 )
 
 // ServiceCreate creates a new Service.
-func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, headers map[string][]string) (types.ServiceCreateResponse, error) {
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (types.ServiceCreateResponse, error) {
+	var headers map[string][]string
+
+	if options.EncodedRegistryAuth != "" {
+		headers = map[string][]string{
+			"X-Registry-Auth": []string{options.EncodedRegistryAuth},
+		}
+	}
+
 	var response types.ServiceCreateResponse
 	resp, err := cli.post(ctx, "/services/create", nil, service, headers)
 	if err != nil {

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -18,7 +18,7 @@ func TestServiceCreateError(t *testing.T) {
 	client := &Client{
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, nil)
+	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -47,7 +47,7 @@ func TestServiceCreate(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, nil)
+	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -4,14 +4,26 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/swarm"
 	"golang.org/x/net/context"
 )
 
 // ServiceUpdate updates a Service.
-func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, headers map[string][]string) error {
-	query := url.Values{}
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) error {
+	var (
+		headers map[string][]string
+		query   = url.Values{}
+	)
+
+	if options.EncodedRegistryAuth != "" {
+		headers = map[string][]string{
+			"X-Registry-Auth": []string{options.EncodedRegistryAuth},
+		}
+	}
+
 	query.Set("version", strconv.FormatUint(version.Index, 10))
+
 	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	ensureReaderClosed(resp)
 	return err

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/swarm"
 )
 
@@ -18,7 +19,7 @@ func TestServiceUpdateError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, nil)
+	err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -68,7 +69,7 @@ func TestServiceUpdate(t *testing.T) {
 			}),
 		}
 
-		err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, nil)
+		err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/types/client.go
+++ b/types/client.go
@@ -246,11 +246,33 @@ type NodeListOptions struct {
 	Filter filters.Args
 }
 
+// ServiceCreateOptions contains the options to use when creating a service.
+type ServiceCreateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+}
+
 // ServiceCreateResponse contains the information returned to a client
 // on the  creation of a new service.
 type ServiceCreateResponse struct {
 	// ID is the ID of the created service.
 	ID string
+}
+
+// ServiceUpdateOptions contains the options to be used for updating services.
+type ServiceUpdateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+
+	// TODO(stevvooe): Consider moving the version parameter of ServiceUpdate
+	// into this field. While it does open API users up to racy writes, most
+	// users may not need that level of consistency in practice.
 }
 
 // ServiceListOptions holds parameters to list  services with.


### PR DESCRIPTION
In general, the Docker API client should avoid exposing HTTP details in
client, as it elides type safety and makes discovery of inputs to a
method more challenging. These have been removed and replaced with an
options type.

We may want to consider arbitrary header transmission through context,
but that is a bigger change.

Proper build tags have been added to experimental features that were
failing during non-tagged build.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

@nishanttotla @tiborvass 