### PR TITLE
types/swarm: make mounts read write by default

### DIFF
--- a/types/swarm/container.go
+++ b/types/swarm/container.go
@@ -30,7 +30,7 @@ type Mount struct {
 	Type     MountType `json:",omitempty"`
 	Source   string    `json:",omitempty"`
 	Target   string    `json:",omitempty"`
-	Writable bool      `json:",omitempty"`
+	ReadOnly bool      `json:",omitempty"`
 
 	BindOptions   *BindOptions   `json:",omitempty"`
 	VolumeOptions *VolumeOptions `json:",omitempty"`


### PR DESCRIPTION
To ensure that the zero-value reflects the defaults for mounts, change
the `Writable` to `ReadOnly`. Adds a breaking api change to address a
point of confusion.

If this PR is not merged by the 1.12 release, this can never be merged,
so just close and move on.

Related to docker/docker#24053.

Signed-off-by: Stephen J Day <stephen.day@docker.com>