### PR TITLE
Add host to the connection error message

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,8 @@ const DefaultVersion string = "1.23"
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
+	// host holds the server address to connect to
+	host string
 	// proto holds the client protocol i.e. unix.
 	proto string
 	// addr holds the client address.
@@ -90,6 +92,7 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 	}
 
 	return &Client{
+		host:              host,
 		proto:             proto,
 		addr:              addr,
 		basePath:          basePath,

--- a/client/errors.go
+++ b/client/errors.go
@@ -8,6 +8,11 @@ import (
 // ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
+// ErrorConnectionFailed returns an error with host in the error message when connection to docker daemon failed.
+func ErrorConnectionFailed(host string) error {
+	return fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", host)
+}
+
 type notFound interface {
 	error
 	NotFound() bool // Is the error a NotFound error

--- a/client/request.go
+++ b/client/request.go
@@ -123,11 +123,11 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 
 		if err, ok := err.(net.Error); ok {
 			if err.Timeout() {
-				return serverResp, ErrConnectionFailed
+				return serverResp, ErrorConnectionFailed(cli.host)
 			}
 			if !err.Temporary() {
 				if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
-					return serverResp, ErrConnectionFailed
+					return serverResp, ErrorConnectionFailed(cli.host)
 				}
 			}
 		}


### PR DESCRIPTION
When running docker client against a swarm cluster and connection to a
node failed, it's not obvious to figure out the targeting host from the
error message.

This is related to issue: https://github.com/docker/swarm/issues/2393

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>