### PR TITLE
Keep Runtime from HostConfig capitalized when stored in json format

### DIFF
--- a/types/container/host_config.go
+++ b/types/container/host_config.go
@@ -308,8 +308,8 @@ type HostConfig struct {
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container
 	ShmSize         int64             // Total shm memory usage
-	Sysctls         map[string]string `json:",omitempty"`        // List of Namespaced sysctls used for the container
-	Runtime         string            `json:"runtime,omitempty"` // Runtime to use with this container
+	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
+	Runtime         string            `json:",omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
 	ConsoleSize [2]int    // Initial console size


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>
