### PR TITLE
types/swarm: add support for log drivers

### DIFF
--- a/types/swarm/swarm.go
+++ b/types/swarm/swarm.go
@@ -18,6 +18,14 @@ type Spec struct {
 	Raft             RaftConfig          `json:",omitempty"`
 	Dispatcher       DispatcherConfig    `json:",omitempty"`
 	CAConfig         CAConfig            `json:",omitempty"`
+
+	// DefaultLogDriver sets the log driver to use at task creation time if
+	// unspecified by a task.
+	//
+	// Updating this value will only have an affect on new tasks. Old tasks
+	// will continue use their previously configured log driver until
+	// recreated.
+	DefaultLogDriver *Driver `json:",omitempty"`
 }
 
 // AcceptancePolicy represents the list of policies.

--- a/types/swarm/task.go
+++ b/types/swarm/task.go
@@ -54,6 +54,11 @@ type TaskSpec struct {
 	Resources     *ResourceRequirements `json:",omitempty"`
 	RestartPolicy *RestartPolicy        `json:",omitempty"`
 	Placement     *Placement            `json:",omitempty"`
+
+	// LogDriver specifies the LogDriver to use for tasks created from this
+	// spec. If not present, the one on cluster default on swarm.Spec will be
+	// used, finally falling back to the engine default if not specified.
+	LogDriver *Driver `json:",omitempty"`
 }
 
 // Resources represents resources (CPU/Memory).


### PR DESCRIPTION
Adds the requisite fields for configuring log drivers on services. Log
drivers are propagated at the task-level, allowing a default to be
configured per cluster. If none are set, the engine default is used.

@tiborvass @vdemeester @thaJeztah @aluzzardi @jpetazzo

Signed-off-by: Stephen J Day <stephen.day@docker.com>