### PR TITLE
Remove execution driver

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -230,7 +230,6 @@ type Info struct {
 	OomKillDisable     bool
 	NGoroutines        int
 	SystemTime         string
-	ExecutionDriver    string
 	LoggingDriver      string
 	CgroupDriver       string
 	NEventsListener    int


### PR DESCRIPTION
We use containerd now and there is no execution driver anymore.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>