### PR TITLE
Remove command from ContainerSpec

### DIFF
--- a/types/swarm/container.go
+++ b/types/swarm/container.go
@@ -6,7 +6,6 @@ import "time"
 type ContainerSpec struct {
 	Image           string            `json:",omitempty"`
 	Labels          map[string]string `json:",omitempty"`
-	Command         []string          `json:",omitempty"`
 	Args            []string          `json:",omitempty"`
 	Env             []string          `json:",omitempty"`
 	Dir             string            `json:",omitempty"`


### PR DESCRIPTION
For 1.12.0, removing `Command` from ContainerSpec. 🐍

Related to https://github.com/docker/docker/pull/24525

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>