### PR TITLE
refactor function getDockerOS() in filegithub.com/docker/engine-api/c…

### DIFF
--- a/client/image_build.go
+++ b/client/image_build.go
@@ -110,10 +110,9 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 }
 
 func getDockerOS(serverHeader string) string {
-	var osType string
 	matches := headerRegexp.FindStringSubmatch(serverHeader)
-	if len(matches) > 0 {
-		osType = matches[1]
+	if len(matches) < 2 {
+		return ""
 	}
-	return osType
+	return matches[1]
 }

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -9,14 +9,13 @@ import (
 )
 
 // ImageHistory returns the changes in an image in history format.
-func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]types.ImageHistory, error) {
-	var history []types.ImageHistory
+func (cli *Client) ImageHistory(ctx context.Context, imageID string) (history []types.ImageHistory, err error) {
 	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", url.Values{}, nil)
 	if err != nil {
-		return history, err
+		return
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&history)
 	ensureReaderClosed(serverResp)
-	return history, err
+	return
 }

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -10,14 +10,14 @@ import (
 )
 
 // ImageList returns a list of images in the docker host.
-func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.Image, error) {
-	var images []types.Image
+func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions) (images []types.Image, err error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
-		if err != nil {
-			return images, err
+		filterJSON, errTmp := filters.ToParamWithVersion(cli.version, options.Filters)
+		if errTmp != nil {
+			err = errTmp
+			return
 		}
 		query.Set("filters", filterJSON)
 	}
@@ -31,10 +31,10 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 
 	serverResp, err := cli.get(ctx, "/images/json", query, nil)
 	if err != nil {
-		return images, err
+		return
 	}
 
 	err = json.NewDecoder(serverResp.body).Decode(&images)
 	ensureReaderClosed(serverResp)
-	return images, err
+	return
 }

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ImageRemove removes an image from the docker host.
-func (cli *Client) ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) ([]types.ImageDelete, error) {
+func (cli *Client) ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) (dels []types.ImageDelete, err error) {
 	query := url.Values{}
 
 	if options.Force {
@@ -21,11 +21,10 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options type
 
 	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
 	if err != nil {
-		return nil, err
+		return
 	}
 
-	var dels []types.ImageDelete
 	err = json.NewDecoder(resp.body).Decode(&dels)
 	ensureReaderClosed(resp)
-	return dels, err
+	return
 }


### PR DESCRIPTION
…lient/image_build.go
- What I did
refactor function “getDockerOS()” in file github.com/docker/engine-api/client/image_build.go
- How I did it
1. remove the local variable -- ”var osType string“

    refactor the statement "if len(matches) > 0 {osType = matches[1]}", because of when len(matches) == 1 , it will throw exception (index out of range)

- How to verify it
local unit test

- Description for the changelog

refactor the statement "if len(matches) > 0 {osType = matches[1]}", because of when len(matches) == 1 , it will throw exception (index out of range). More Robust !!!
Signed-off-by: yuanxiao <yuan.xiao5@zte.com.cn>