### PR TITLE
Make darwin default docker host the same as unix

### DIFF
--- a/client/client_darwin.go
+++ b/client/client_darwin.go
@@ -1,4 +1,0 @@
-package client
-
-// DefaultDockerHost defines os specific default if DOCKER_HOST is unset
-const DefaultDockerHost = "tcp://127.0.0.1:2375"

--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd solaris openbsd
+// +build linux freebsd solaris openbsd darwin
 
 package client
 


### PR DESCRIPTION
The reason for this is that docker already default for unix docker in darwin too.
Also now that we have Docker for Mac, we can talk to the daemon using a unix socket.
So it seems like it makes a lot more sense that unix docker is the default.