### PR TITLE
Add `--force` in `docker volume rm` to fix out-of-band volume driver deletion

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -131,5 +131,5 @@ type VolumeAPIClient interface {
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
-	VolumeRemove(ctx context.Context, volumeID string) error
+	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 }

--- a/client/volume_remove.go
+++ b/client/volume_remove.go
@@ -1,10 +1,18 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
 
 // VolumeRemove removes a volume from the docker host.
-func (cli *Client) VolumeRemove(ctx context.Context, volumeID string) error {
-	resp, err := cli.delete(ctx, "/volumes/"+volumeID, nil, nil)
+func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
+	query := url.Values{}
+	if force {
+		query.Set("force", "1")
+	}
+	resp, err := cli.delete(ctx, "/volumes/"+volumeID, query, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -16,7 +16,7 @@ func TestVolumeRemoveError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.VolumeRemove(context.Background(), "volume_id")
+	err := client.VolumeRemove(context.Background(), "volume_id", false)
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -40,7 +40,7 @@ func TestVolumeRemove(t *testing.T) {
 		}),
 	}
 
-	err := client.VolumeRemove(context.Background(), "volume_id")
+	err := client.VolumeRemove(context.Background(), "volume_id", false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fix is related to pull request in docker:

https://github.com/docker/docker/pull/23436

And this fix tries to address the issue raised in

https://github.com/docker/docker/issues/23367

where an out-of-band volume driver deletion leaves some data in docker. This prevent the reuse of deleted volume names (by out-of-band volume driver like flocker).

This fix adds a `--force` field in `docker volume rm` to forcefully purge the data of the volume that has already been deleted.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>