### PR TITLE
types/configs: Add Env to ExecConfig struct

### DIFF
--- a/types/configs.go
+++ b/types/configs.go
@@ -49,6 +49,7 @@ type ExecConfig struct {
 	AttachStdout bool     // Attach the standard output
 	Detach       bool     // Execute in detach mode
 	DetachKeys   string   // Escape keys for detach
+	Env          []string // Environment variables
 	Cmd          []string // Execution commands and args
 }
 


### PR DESCRIPTION
This allows env variables to be passed to exec command.

Docker Engine PR: https://github.com/docker/docker/pull/24594