### PR TITLE
api: default log driver goes under task defaults

### DIFF
--- a/types/swarm/swarm.go
+++ b/types/swarm/swarm.go
@@ -18,6 +18,7 @@ type Spec struct {
 	Raft             RaftConfig          `json:",omitempty"`
 	Dispatcher       DispatcherConfig    `json:",omitempty"`
 	CAConfig         CAConfig            `json:",omitempty"`
+	TaskDefaults     TaskDefaults        `json:",omitempty"`
 }
 
 // AcceptancePolicy represents the list of policies.
@@ -35,14 +36,17 @@ type Policy struct {
 // OrchestrationConfig represents orchestration configuration.
 type OrchestrationConfig struct {
 	TaskHistoryRetentionLimit int64 `json:",omitempty"`
+}
 
-	// DefaultLogDriver selects the log driver to use for tasks created in the
+// TaskDefaults parameterizes cluster-level task creation with default values.
+type TaskDefaults struct {
+	// LogDriver selects the log driver to use for tasks created in the
 	// orchestrator if unspecified by a service.
 	//
 	// Updating this value will only have an affect on new tasks. Old tasks
 	// will continue use their previously configured log driver until
 	// recreated.
-	DefaultLogDriver *Driver `json:",omitempty"`
+	LogDriver *Driver `json:",omitempty"`
 }
 
 // RaftConfig represents raft configuration.


### PR DESCRIPTION
In general, we'd like to avoid pollute the top-level space of the
cluster configuration with specific items. This parameterizes task
creation using a `TaskDefaults` subsection. It is arguable that this is
part of the orchestrator, but it is possible to allow task creation
outside of the orchestrator in the future.

Supercedes #322. Wait till we merge docker/swarmkit#1185 before merging this.

Signed-off-by: Stephen J Day <stephen.day@docker.com>