### PR TITLE
Replace secrets with join tokens

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -115,7 +115,7 @@ type SwarmAPIClient interface {
 	SwarmJoin(ctx context.Context, req swarm.JoinRequest) error
 	SwarmLeave(ctx context.Context, force bool) error
 	SwarmInspect(ctx context.Context) (swarm.Swarm, error)
-	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error
+	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error
 }
 
 // SystemAPIClient defines API client methods for the system

--- a/client/swarm_update.go
+++ b/client/swarm_update.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -9,9 +10,11 @@ import (
 )
 
 // SwarmUpdate updates the Swarm.
-func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error {
+func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
+	query.Set("rotate_worker_token", fmt.Sprintf("%v", flags.RotateWorkerToken))
+	query.Set("rotate_manager_token", fmt.Sprintf("%v", flags.RotateManagerToken))
 	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -18,7 +18,7 @@ func TestSwarmUpdateError(t *testing.T) {
 		transport: newMockClient(nil, errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{})
+	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
 	if err == nil || err.Error() != "Error response from daemon: Server error" {
 		t.Fatalf("expected a Server Error, got %v", err)
 	}
@@ -42,7 +42,7 @@ func TestSwarmUpdate(t *testing.T) {
 		}),
 	}
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{})
+	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/swarm/node.go
+++ b/types/swarm/node.go
@@ -15,7 +15,6 @@ type Node struct {
 type NodeSpec struct {
 	Annotations
 	Role         NodeRole         `json:",omitempty"`
-	Membership   NodeMembership   `json:",omitempty"`
 	Availability NodeAvailability `json:",omitempty"`
 }
 
@@ -27,16 +26,6 @@ const (
 	NodeRoleWorker NodeRole = "worker"
 	// NodeRoleManager MANAGER
 	NodeRoleManager NodeRole = "manager"
-)
-
-// NodeMembership represents the membership of a node.
-type NodeMembership string
-
-const (
-	// NodeMembershipPending PENDING
-	NodeMembershipPending NodeMembership = "pending"
-	// NodeMembershipAccepted ACCEPTED
-	NodeMembershipAccepted NodeMembership = "accepted"
 )
 
 // NodeAvailability represents the availability of a node.

--- a/types/swarm/swarm.go
+++ b/types/swarm/swarm.go
@@ -6,31 +6,25 @@ import "time"
 type Swarm struct {
 	ID string
 	Meta
-	Spec Spec
+	Spec       Spec
+	JoinTokens JoinTokens
+}
+
+// JoinTokens contains the tokens workers and managers need to join the swarm.
+type JoinTokens struct {
+	Worker  string
+	Manager string
 }
 
 // Spec represents the spec of a swarm.
 type Spec struct {
 	Annotations
 
-	AcceptancePolicy AcceptancePolicy    `json:",omitempty"`
-	Orchestration    OrchestrationConfig `json:",omitempty"`
-	Raft             RaftConfig          `json:",omitempty"`
-	Dispatcher       DispatcherConfig    `json:",omitempty"`
-	CAConfig         CAConfig            `json:",omitempty"`
-	TaskDefaults     TaskDefaults        `json:",omitempty"`
-}
-
-// AcceptancePolicy represents the list of policies.
-type AcceptancePolicy struct {
-	Policies []Policy `json:",omitempty"`
-}
-
-// Policy represents a role, autoaccept and secret.
-type Policy struct {
-	Role       NodeRole
-	Autoaccept bool
-	Secret     *string `json:",omitempty"`
+	Orchestration OrchestrationConfig `json:",omitempty"`
+	Raft          RaftConfig          `json:",omitempty"`
+	Dispatcher    DispatcherConfig    `json:",omitempty"`
+	CAConfig      CAConfig            `json:",omitempty"`
+	TaskDefaults  TaskDefaults        `json:",omitempty"`
 }
 
 // OrchestrationConfig represents orchestration configuration.
@@ -95,9 +89,7 @@ type JoinRequest struct {
 	ListenAddr    string
 	AdvertiseAddr string
 	RemoteAddrs   []string
-	Secret        string // accept by secret
-	CACertHash    string
-	Manager       bool
+	JoinToken     string // accept by secret
 }
 
 // LocalNodeState represents the state of the local node.
@@ -126,11 +118,16 @@ type Info struct {
 	RemoteManagers []Peer
 	Nodes          int
 	Managers       int
-	CACertHash     string
 }
 
 // Peer represents a peer.
 type Peer struct {
 	NodeID string
 	Addr   string
+}
+
+// UpdateFlags contains flags for SwarmUpdate.
+type UpdateFlags struct {
+	RotateWorkerToken  bool
+	RotateManagerToken bool
 }


### PR DESCRIPTION
Needed for docker/docker#24823.

This changes datastructures in accordance with the upstream swarmkit
changes. It also adds flags to SwarmUpdate to allow token rotation.