### PR TITLE
[WIP] types/swarm: move network attachments to TaskSpec

### DIFF
--- a/types/swarm/service.go
+++ b/types/swarm/service.go
@@ -16,11 +16,10 @@ type ServiceSpec struct {
 
 	// TaskTemplate defines how the service should construct new tasks when
 	// orchestrating this service.
-	TaskTemplate TaskSpec                  `json:",omitempty"`
-	Mode         ServiceMode               `json:",omitempty"`
-	UpdateConfig *UpdateConfig             `json:",omitempty"`
-	Networks     []NetworkAttachmentConfig `json:",omitempty"`
-	EndpointSpec *EndpointSpec             `json:",omitempty"`
+	TaskTemplate TaskSpec      `json:",omitempty"`
+	Mode         ServiceMode   `json:",omitempty"`
+	UpdateConfig *UpdateConfig `json:",omitempty"`
+	EndpointSpec *EndpointSpec `json:",omitempty"`
 }
 
 // ServiceMode represents the mode of a service.

--- a/types/swarm/task.go
+++ b/types/swarm/task.go
@@ -50,10 +50,11 @@ type Task struct {
 
 // TaskSpec represents the spec of a task.
 type TaskSpec struct {
-	ContainerSpec ContainerSpec         `json:",omitempty"`
-	Resources     *ResourceRequirements `json:",omitempty"`
-	RestartPolicy *RestartPolicy        `json:",omitempty"`
-	Placement     *Placement            `json:",omitempty"`
+	ContainerSpec ContainerSpec             `json:",omitempty"`
+	Resources     *ResourceRequirements     `json:",omitempty"`
+	RestartPolicy *RestartPolicy            `json:",omitempty"`
+	Placement     *Placement                `json:",omitempty"`
+	Networks      []NetworkAttachmentConfig `json:",omitempty"`
 
 	// LogDriver specifies the LogDriver to use for tasks created from this
 	// spec. If not present, the one on cluster default on swarm.Spec will be


### PR DESCRIPTION
Networks are a propery of the `Task`, not the service. Without this
change, it will make it harder to do pluggable orchestrators in the
future that aren't bound to a service.

Please see https://github.com/docker/swarmkit/pull/1205 for details.

cc @thaJeztah @aluzzardi 

Signed-off-by: Stephen J Day <stephen.day@docker.com>