### PR TITLE
Add swarm.Swarm to swarm.Info…

### DIFF
--- a/types/swarm/swarm.go
+++ b/types/swarm/swarm.go
@@ -118,6 +118,8 @@ type Info struct {
 	RemoteManagers []Peer
 	Nodes          int
 	Managers       int
+
+	Cluster Swarm
 }
 
 // Peer represents a peer.


### PR DESCRIPTION
… in order to display Swarm information in the `/info` endpoint 🐮.

Related to docker/docker#24492

/cc @thaJeztah @tiborvass @icecrime 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>