### PR TITLE
Carry #339: Remove join-tokens from info

### DIFF
--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -32,7 +32,9 @@ func TestSwarmInspect(t *testing.T) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
 			content, err := json.Marshal(swarm.Swarm{
-				ID: "swarm_id",
+				ClusterInfo: swarm.ClusterInfo{
+					ID: "swarm_id",
+				},
 			})
 			if err != nil {
 				return nil, err

--- a/types/swarm/swarm.go
+++ b/types/swarm/swarm.go
@@ -2,11 +2,17 @@ package swarm
 
 import "time"
 
-// Swarm represents a swarm.
-type Swarm struct {
+// ClusterInfo represents info about a the cluster for outputing in "info"
+// it contains the same information as "Swarm", but without the JoinTokens
+type ClusterInfo struct {
 	ID string
 	Meta
-	Spec       Spec
+	Spec Spec
+}
+
+// Swarm represents a swarm.
+type Swarm struct {
+	ClusterInfo
 	JoinTokens JoinTokens
 }
 
@@ -119,7 +125,7 @@ type Info struct {
 	Nodes          int
 	Managers       int
 
-	Cluster Swarm
+	Cluster ClusterInfo
 }
 
 // Peer represents a peer.


### PR DESCRIPTION
join-tokens are not needed for the endpoint

relates to docker/docker#25134
Closes #339