### PR TITLE
Default host for DockerForMac is unix socket

### DIFF
--- a/client/client_darwin.go
+++ b/client/client_darwin.go
@@ -1,4 +1,4 @@
 package client
 
 // DefaultDockerHost defines os specific default if DOCKER_HOST is unset
-const DefaultDockerHost = "tcp://127.0.0.1:2375"
+const DefaultDockerHost = "unix:///var/run/docker.sock"


### PR DESCRIPTION
With reference to  https://github.com/docker/libcompose/issues/279, default docker socket should be unix instead of tcp. This fixes the engine-api for docker for mac.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>