### PR TITLE
Add isolation to info struct

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -260,6 +260,7 @@ type Info struct {
 	// running when the daemon is shutdown or upon daemon start if
 	// running containers are detected
 	LiveRestoreEnabled bool
+	Isolation          container.Isolation
 }
 
 // PluginsInfo is a temp struct holding Plugins name


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Apart from being useful information to expose through `INFO` on the engine, this is necessary for the bring up of CI on Hyper-V containers on Windows. Some tests need to behave differently depending on the isolation mode of the daemon being tested (for example, in a Hyper-V container, you can't find and kill a container process from the host as it's running inside a utility VM). 