### PR TITLE
Add Annotations to Task definition to fix partial/full filter issue in `service tasks --filter`

### DIFF
--- a/types/swarm/task.go
+++ b/types/swarm/task.go
@@ -38,6 +38,7 @@ const (
 type Task struct {
 	ID string
 	Meta
+	Annotations
 
 	Spec                TaskSpec            `json:",omitempty"`
 	ServiceID           string              `json:",omitempty"`


### PR DESCRIPTION
This fix is related to docker pull request:
https://github.com/docker/docker/pull/24850

and swarmkit pull request:
https://github.com/docker/swarmkit/pull/1193

Basically, this fix adds Annotations to Task definition so that
Task name could be saved. The Task name is defined as
```
<ServiceName>.<Slot>.<TaskID>
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>