### PR TITLE
add fun String() for NetIPNet

### DIFF
--- a/types/registry/registry.go
+++ b/types/registry/registry.go
@@ -16,6 +16,11 @@ type ServiceConfig struct {
 // unmarshalled to JSON
 type NetIPNet net.IPNet
 
+// String returns the CIDR notation of ipnet
+func (ipnet *NetIPNet) String() string {
+	return (*net.IPNet)(ipnet).String()
+}
+
 // MarshalJSON returns the JSON representation of the IPNet
 func (ipnet *NetIPNet) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*net.IPNet)(ipnet).String())


### PR DESCRIPTION
Add this func, so there is no need to combine the attribute to format output.
like in docker/api/client/info.go, registry is a type of `NetIPNet`:
```
fmt.Fprintf(dockerCli.Out(), " %s/%d\n", registry.IP.String(), mask)
```

The same in docker/registry package.

Signed-off-by: allencloud <allen.sun@daocloud.io>