### PR TITLE
Fix wrong field name on mount: s/Populate/NoCopy

### DIFF
--- a/types/mount/mount.go
+++ b/types/mount/mount.go
@@ -46,7 +46,7 @@ type BindOptions struct {
 
 // VolumeOptions represents the options for a mount of type volume.
 type VolumeOptions struct {
-	Populate     bool              `json:",omitempty"`
+	NoCopy       bool              `json:",omitempty"`
 	Labels       map[string]string `json:",omitempty"`
 	DriverConfig *Driver           `json:",omitempty"`
 }


### PR DESCRIPTION
This was inadvertently changed in #258