### PR TITLE
Use dialer from client to set up hijacked connection

### DIFF
--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"net/http"
 
 	"github.com/docker/engine-api/client/transport"
@@ -44,6 +45,10 @@ func newMockClient(tlsConfig *tls.Config, doer func(*http.Request) (*http.Respon
 // Do executes the supplied function for the mock.
 func (m mockClient) Do(req *http.Request) (*http.Response, error) {
 	return m.do(req)
+}
+
+func (m mockClient) Dial(network, addr string) (net.Conn, error) {
+	return new(net.Dialer).Dial(network, addr)
 }
 
 func errorMock(statusCode int, message string) func(req *http.Request) (*http.Response, error) {

--- a/client/transport/client.go
+++ b/client/transport/client.go
@@ -2,8 +2,15 @@ package transport
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 )
+
+// Dialer is an interface thet clients must implement
+// to be able to set up hijacked connections.
+type Dialer interface {
+	Dial(string, string) (net.Conn, error)
+}
 
 // Sender is an interface that clients must implement
 // to be able to send requests to a remote connection.
@@ -14,6 +21,7 @@ type Sender interface {
 
 // Client is an interface that abstracts all remote connections.
 type Client interface {
+	Dialer
 	Sender
 	// Secure tells whether the connection is secure or not.
 	Secure() bool

--- a/client/transport/transport.go
+++ b/client/transport/transport.go
@@ -3,6 +3,7 @@ package transport
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/docker/go-connections/sockets"
@@ -44,6 +45,10 @@ func NewTransportWithHTTP(proto, addr string, client *http.Client) (Client, erro
 // CancelRequest stops a request execution.
 func (a *apiTransport) CancelRequest(req *http.Request) {
 	a.transport.CancelRequest(req)
+}
+
+func (a *apiTransport) Dial(network, addr string) (net.Conn, error) {
+	return a.transport.Dial(network, addr)
 }
 
 // defaultTransport creates a new http.Transport with Docker's


### PR DESCRIPTION
After some digging with @devwout, we discovered that `postHijacked` just uses `net.Dial` instead of the one from the underlaying transport. We're having problems with this because we tunnel the docker socket over SSH.

The `tlsDialWithDialer` now used a `Dialer` interface instead of `net.Dialer`, which means we don't get all of the timeout options. However these were not used (`new(net.Dialer)`), so I dumped them.

There was no test for `TestContainerExecAttach`, I also didn't add one.

This probably needs some additional work though.

Thanks!