### PR TITLE
swarm/container: add support for TTY and supplementary groups

### DIFF
--- a/types/swarm/container.go
+++ b/types/swarm/container.go
@@ -15,6 +15,8 @@ type ContainerSpec struct {
 	Env             []string          `json:",omitempty"`
 	Dir             string            `json:",omitempty"`
 	User            string            `json:",omitempty"`
+	Groups          []string          `json:",omitempty"`
+	TTY             bool              `json:",omitempty"`
 	Mounts          []mount.Mount     `json:",omitempty"`
 	StopGracePeriod *time.Duration    `json:",omitempty"`
 }


### PR DESCRIPTION
These are supported in swarmkit. Let's make sure we have the relevant fields in docker.

This will need to be followed up with a support PR in docker/docker with the appropriate flags, but this can be merged right away.

Signed-off-by: Stephen J Day <stephen.day@docker.com>