### PR TITLE
Allow Docker daemon to bind to different IP than --cluster-advertise.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -252,6 +252,7 @@ type Info struct {
 	ServerVersion      string
 	ClusterStore       string
 	ClusterAdvertise   string
+	ClusterListen      string
 	SecurityOptions    []string
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string


### PR DESCRIPTION
This fix is part of the pull request:
https://github.com/docker/docker/pull/22663

that allows docker daemon to bind to a different IP than
--cluster-advertise.

This fix adds `ClusterListen` so that docker daemon could use this value
to store the listen address for overlay networks.

This fix is related to:
https://github.com/docker/libnetwork/pull/1175

This fix is related to issues:
https://github.com/docker/docker/issues/22008
https://github.com/docker/docker/issues/22087

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>