### PR TITLE
Fixes more issues swallowing connection errors

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -121,9 +121,14 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 			return serverResp, err
 		}
 
-		if err, ok := err.(net.Error); ok && !err.Temporary() {
-			if !strings.Contains(err.Error(), "HTTP response to HTTPS client") {
+		if err, ok := err.(net.Error); ok {
+			if err.Timeout() {
 				return serverResp, ErrConnectionFailed
+			}
+			if !err.Temporary() {
+				if strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
+					return serverResp, ErrConnectionFailed
+				}
 			}
 		}
 		return serverResp, fmt.Errorf("An error occurred trying to connect: %v", err)


### PR DESCRIPTION
Really need to make sure we are only returning `ErrConnectionFailed`
when it's really a failed connection, not just something that reports as
a non-temporary error.

This fixes more tests on docker CI, see https://jenkins.dockerproject.org/job/Docker-PRs/31060/console for reference