### PR TITLE
Changes required to support windows service discovery

### DIFF
--- a/types/network/network.go
+++ b/types/network/network.go
@@ -44,6 +44,7 @@ type EndpointSettings struct {
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
 	MacAddress          string
+	DNS                 []string
 }
 
 // NetworkingConfig represents the container's networking configuration for each of its interfaces


### PR DESCRIPTION
In windows dns servers are associated with endpoints and not with sandbox. We need this change in order for us to pass DNS information to the endpoint creation API. This will enable us to implement service discovery for windows. 

The related changes for service discovery are in my private branch for now https://github.com/msabansal/docker/tree/dnssupport

Signed-off-by: msabansal <sabansal@microsoft.com>