### PR TITLE
swarm: clarify meaning of time related fields

### DIFF
--- a/types/swarm/swarm.go
+++ b/types/swarm/swarm.go
@@ -54,13 +54,27 @@ type RaftConfig struct {
 	SnapshotInterval           uint64 `json:",omitempty"`
 	KeepOldSnapshots           uint64 `json:",omitempty"`
 	LogEntriesForSlowFollowers uint64 `json:",omitempty"`
-	HeartbeatTick              uint32 `json:",omitempty"`
-	ElectionTick               uint32 `json:",omitempty"`
+
+	// ElectionTick is the number of ticks that a follower will wait for a message
+	// from the leader before becoming a candidate and starting an election.
+	// ElectionTick must be greater than HeartbeatTick.
+	//
+	// A tick currently defaults to one second, so these translate directly to
+	// seconds currently, but this is NOT guaranteed.
+	ElectionTick int
+
+	// HeartbeatTick is the number of ticks between heartbeats. Every
+	// HeartbeatTick ticks, the leader will send a heartbeat to the
+	// followers.
+	//
+	// A tick currently defaults to one second, so these translate directly to
+	// seconds currently, but this is NOT guaranteed.
+	HeartbeatTick int
 }
 
 // DispatcherConfig represents dispatcher configuration.
 type DispatcherConfig struct {
-	HeartbeatPeriod uint64 `json:",omitempty"`
+	HeartbeatPeriod time.Duration `json:",omitempty"`
 }
 
 // CAConfig represents CA configuration.


### PR DESCRIPTION
Several fields in the `RaftConfig` and `DispatcherConfig` structures
lack clarification about their meaning in relation to time. While all
these fields describe a time-period, they have subtle yet important
differences in their meanings.

`HeartbeatPeriod` is an open time period, meaning the amount of time
between heartbeats for nodes communicating with the dispatcher. This
field has always been specified in nanoseconds and has been converted
directly to a `time.Duration` field. This will have impact except for a
slightly different type. The values used via the API will be identical,
so there is no impact.

`HeartbeatTick` and `ElectionTick` specify the period in units of ticks,
which are configured as one second in the manager. The role of these
fields is clarified and their relation with time is described
accordingly.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Thanks to @aaronlehmann for the descriptions.