### PR TITLE
Change IPAM driver type to pointer to avoid default value

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -475,7 +475,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool
 	Driver         string
 	EnableIPv6     bool
-	IPAM           network.IPAM
+	IPAM           *network.IPAM
 	Internal       bool
 	Options        map[string]string
 	Labels         map[string]string


### PR DESCRIPTION
This fix tries to address the issue raised in #368 and https://github.com/docker/docker/issues/25735
where NetworkCreate needs to set up the IPAM driver type. Otherwise
an error will be returned.

This fix change IPAM driver type to pointer so that `/networks/create`
does not the explicit specification of IPAM driver any more.

This fix fixes #368.

This fix is related to https://github.com/docker/docker/pull/25803

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>