### PR TITLE
Windows: Support for stats (docker #25737)

### DIFF
--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -1,15 +1,15 @@
 package client
 
 import (
-	"io"
 	"net/url"
 
+	"github.com/docker/engine-api/types"
 	"golang.org/x/net/context"
 )
 
 // ContainerStats returns near realtime stats for a given container.
 // It's up to the caller to close the io.ReadCloser returned.
-func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (io.ReadCloser, error) {
+func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
 	query := url.Values{}
 	query.Set("stream", "0")
 	if stream {
@@ -18,7 +18,9 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return nil, err
+		return types.ContainerStats{}, err
 	}
-	return resp.body, err
+
+	osType := GetDockerOS(resp.header.Get("Server"))
+	return types.ContainerStats{Body: resp.body, OSType: osType}, err
 }

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -54,12 +54,12 @@ func TestContainerStats(t *testing.T) {
 				}, nil
 			}),
 		}
-		body, err := client.ContainerStats(context.Background(), "container_id", c.stream)
+		resp, err := client.ContainerStats(context.Background(), "container_id", c.stream)
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer body.Close()
-		content, err := ioutil.ReadAll(body)
+		defer resp.Body.Close()
+		content, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -39,7 +39,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 		return types.ImageBuildResponse{}, err
 	}
 
-	osType := getDockerOS(serverResp.header.Get("Server"))
+	osType := GetDockerOS(serverResp.header.Get("Server"))
 
 	return types.ImageBuildResponse{
 		Body:   serverResp.body,
@@ -113,7 +113,8 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
 	return query, nil
 }
 
-func getDockerOS(serverHeader string) string {
+// GetDockerOS returns the operating system based on the server header from the daemon.
+func GetDockerOS(serverHeader string) string {
 	var osType string
 	matches := headerRegexp.FindStringSubmatch(serverHeader)
 	if len(matches) > 0 {

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -222,7 +222,7 @@ func TestGetDockerOS(t *testing.T) {
 		"Foo/v1.22 (bar)":        "",
 	}
 	for header, os := range cases {
-		g := getDockerOS(header)
+		g := GetDockerOS(header)
 		if g != os {
 			t.Fatalf("Expected %s, got %s", os, g)
 		}

--- a/client/interface.go
+++ b/client/interface.go
@@ -51,7 +51,7 @@ type ContainerAPIClient interface {
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
-	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
+	ContainerStats(ctx context.Context, container string, stream bool) (types.ContainerStats, error)
 	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
 	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)

--- a/types/stats.go
+++ b/types/stats.go
@@ -4,7 +4,8 @@ package types
 
 import "time"
 
-// ThrottlingData stores CPU throttling stats of one running container
+// ThrottlingData stores CPU throttling stats of one running container.
+// Not used on Windows.
 type ThrottlingData struct {
 	// Number of periods with throttling active
 	Periods uint64 `json:"periods"`
@@ -17,42 +18,68 @@ type ThrottlingData struct {
 // CPUUsage stores All CPU stats aggregated since container inception.
 type CPUUsage struct {
 	// Total CPU time consumed.
-	// Units: nanoseconds.
+	// Units: nanoseconds (Linux)
+	// Units: 100's of nanoseconds (Windows)
 	TotalUsage uint64 `json:"total_usage"`
-	// Total CPU time consumed per core.
+
+	// Total CPU time consumed per core (Linux). Not used on Windows.
 	// Units: nanoseconds.
-	PercpuUsage []uint64 `json:"percpu_usage"`
-	// Time spent by tasks of the cgroup in kernel mode.
-	// Units: nanoseconds.
+	PercpuUsage []uint64 `json:"percpu_usage,omitempty"`
+
+	// Time spent by tasks of the cgroup in kernel mode (Linux).
+	// Time spent by all container processes in kernel mode (Windows).
+	// Units: nanoseconds (Linux).
+	// Units: 100's of nanoseconds (Windows). Not populated for Hyper-V Containers.
 	UsageInKernelmode uint64 `json:"usage_in_kernelmode"`
-	// Time spent by tasks of the cgroup in user mode.
-	// Units: nanoseconds.
+
+	// Time spent by tasks of the cgroup in user mode (Linux).
+	// Time spent by all container processes in user mode (Windows).
+	// Units: nanoseconds (Linux).
+	// Units: 100's of nanoseconds (Windows). Not populated for Hyper-V Containers
 	UsageInUsermode uint64 `json:"usage_in_usermode"`
 }
 
 // CPUStats aggregates and wraps all CPU related info of container
 type CPUStats struct {
-	CPUUsage       CPUUsage       `json:"cpu_usage"`
-	SystemUsage    uint64         `json:"system_cpu_usage"`
+	// CPU Usage. Linux and Windows.
+	CPUUsage CPUUsage `json:"cpu_usage"`
+
+	// System Usage. Linux only.
+	SystemUsage uint64 `json:"system_cpu_usage,omitempty"`
+
+	// Throttling Data. Linux only.
 	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
 }
 
-// MemoryStats aggregates All memory stats since container inception
+// MemoryStats aggregates all memory stats since container inception on Linux.
+// Windows returns stats for commit and private working set only.
 type MemoryStats struct {
+	// Linux Memory Stats
+
 	// current res_counter usage for memory
-	Usage uint64 `json:"usage"`
+	Usage uint64 `json:"usage,omitempty"`
 	// maximum usage ever recorded.
-	MaxUsage uint64 `json:"max_usage"`
+	MaxUsage uint64 `json:"max_usage,omitempty"`
 	// TODO(vishh): Export these as stronger types.
 	// all the stats exported via memory.stat.
-	Stats map[string]uint64 `json:"stats"`
+	Stats map[string]uint64 `json:"stats,omitempty"`
 	// number of times memory usage hits limits.
-	Failcnt uint64 `json:"failcnt"`
-	Limit   uint64 `json:"limit"`
+	Failcnt uint64 `json:"failcnt,omitempty"`
+	Limit   uint64 `json:"limit,omitempty"`
+
+	// Windows Memory Stats
+	// See https://technet.microsoft.com/en-us/magazine/ff382715.aspx
+
+	// committed bytes
+	Commit uint64 `json:"commitbytes,omitempty"`
+	// peak committed bytes
+	CommitPeak uint64 `json:"commitpeakbytes,omitempty"`
+	// private working set
+	PrivateWorkingSet uint64 `json:"privateworkingset,omitempty"`
 }
 
 // BlkioStatEntry is one small entity to store a piece of Blkio stats
-// TODO Windows: This can be factored out
+// Not used on Windows.
 type BlkioStatEntry struct {
 	Major uint64 `json:"major"`
 	Minor uint64 `json:"minor"`
@@ -60,8 +87,10 @@ type BlkioStatEntry struct {
 	Value uint64 `json:"value"`
 }
 
-// BlkioStats stores All IO service stats for data read and write
-// TODO Windows: This can be factored out
+// BlkioStats stores All IO service stats for data read and write.
+// This is a Linux specific structure as the differences between expressing
+// block I/O on Windows and Linux are sufficiently significant to make
+// little sense attempting to morph into a combined structure.
 type BlkioStats struct {
 	// number of bytes transferred to and from the block device
 	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive"`
@@ -74,17 +103,38 @@ type BlkioStats struct {
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive"`
 }
 
-// NetworkStats aggregates All network stats of one container
-// TODO Windows: This will require refactoring
+// StorageStats is the disk I/O stats for read/write on Windows.
+type StorageStats struct {
+	ReadCountNormalized  uint64 `json:"read_count_normalized,omitempty"`
+	ReadSizeBytes        uint64 `json:"read_size_bytes,omitempty"`
+	WriteCountNormalized uint64 `json:"write_count_normalized,omitempty"`
+	WriteSizeBytes       uint64 `json:"write_size_bytes,omitempty"`
+}
+
+// NetworkStats aggregates the network stats of one container
 type NetworkStats struct {
-	RxBytes   uint64 `json:"rx_bytes"`
+	// Bytes received. Windows and Linux.
+	RxBytes uint64 `json:"rx_bytes"`
+	// Packets received. Windows and Linux.
 	RxPackets uint64 `json:"rx_packets"`
-	RxErrors  uint64 `json:"rx_errors"`
+	// Received errors. Not used on Windows. Note that we dont `omitempty` this
+	// field as it is expected in the >=v1.21 API stats structure.
+	RxErrors uint64 `json:"rx_errors"`
+	// Incoming packets dropped. Windows and Linux.
 	RxDropped uint64 `json:"rx_dropped"`
-	TxBytes   uint64 `json:"tx_bytes"`
+	// Bytes sent. Windows and Linux.
+	TxBytes uint64 `json:"tx_bytes"`
+	// Packets sent. Windows and Linux.
 	TxPackets uint64 `json:"tx_packets"`
-	TxErrors  uint64 `json:"tx_errors"`
+	// Sent errors. Not used on Windows. Note that we dont `omitempty` this
+	// field as it is expected in the >=v1.21 API stats structure.
+	TxErrors uint64 `json:"tx_errors"`
+	// Outgoing packets dropped. Windows and Linux.
 	TxDropped uint64 `json:"tx_dropped"`
+	// Endpoint ID. Not used on Linux.
+	EndpointID string `json:"endpoint_id,omitempty"`
+	// Instance ID. Not used on Linux.
+	InstanceID string `json:"instance_id,omitempty"`
 }
 
 // PidsStats contains the stats of a container's pids
@@ -98,12 +148,22 @@ type PidsStats struct {
 
 // Stats is Ultimate struct aggregating all types of stats of one container
 type Stats struct {
-	Read        time.Time   `json:"read"`
-	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"`
+	// Common stats
+	Read    time.Time `json:"read"`
+	PreRead time.Time `json:"preread"`
+
+	// Linux specific stats, not populated on Windows.
+	PidsStats  PidsStats  `json:"pids_stats,omitempty"`
+	BlkioStats BlkioStats `json:"blkio_stats,omitempty"`
+
+	// Windows specific stats, not populated on Linux.
+	NumProcs     uint32       `json:"num_procs"`
+	StorageStats StorageStats `json:"storage_stats,omitempty"`
+
+	// Shared stats
 	CPUStats    CPUStats    `json:"cpu_stats,omitempty"`
+	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"` // "Pre"="Previous"
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
-	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
-	PidsStats   PidsStats   `json:"pids_stats,omitempty"`
 }
 
 // StatsJSON is newly used Networks

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -180,6 +181,13 @@ type ContainerPathStat struct {
 	Mode       os.FileMode `json:"mode"`
 	Mtime      time.Time   `json:"mtime"`
 	LinkTarget string      `json:"linkTarget"`
+}
+
+// ContainerStats contains resonse of Remote API:
+// GET "/stats"
+type ContainerStats struct {
+	Body   io.ReadCloser `json:"body"`
+	OSType string        `json:"ostype"`
 }
 
 // ContainerProcessList contains response of Remote API:


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds support for docker stats on Windows. See https://github.com/docker/docker/pull/25737 for detailed information.