### PR TITLE
Add NetworkAttachmentConfig to TaskSpec

### DIFF
--- a/types/swarm/network.go
+++ b/types/swarm/network.go
@@ -64,6 +64,7 @@ type NetworkSpec struct {
 	DriverConfiguration *Driver      `json:",omitempty"`
 	IPv6Enabled         bool         `json:",omitempty"`
 	Internal            bool         `json:",omitempty"`
+	Attachable          bool         `json:",omitempty"`
 	IPAMOptions         *IPAMOptions `json:",omitempty"`
 }
 

--- a/types/swarm/task.go
+++ b/types/swarm/task.go
@@ -51,10 +51,11 @@ type Task struct {
 
 // TaskSpec represents the spec of a task.
 type TaskSpec struct {
-	ContainerSpec ContainerSpec         `json:",omitempty"`
-	Resources     *ResourceRequirements `json:",omitempty"`
-	RestartPolicy *RestartPolicy        `json:",omitempty"`
-	Placement     *Placement            `json:",omitempty"`
+	ContainerSpec ContainerSpec             `json:",omitempty"`
+	Resources     *ResourceRequirements     `json:",omitempty"`
+	RestartPolicy *RestartPolicy            `json:",omitempty"`
+	Placement     *Placement                `json:",omitempty"`
+	Networks      []NetworkAttachmentConfig `json:",omitempty"`
 
 	// LogDriver specifies the LogDriver to use for tasks created from this
 	// spec. If not present, the one on cluster default on swarm.Spec will be

--- a/types/types.go
+++ b/types/types.go
@@ -456,6 +456,7 @@ type NetworkResource struct {
 	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
 	IPAM       network.IPAM                // IPAM is the network's IP Address Management
 	Internal   bool                        // Internal represents if the network is used internal only
+	Attachable bool                        // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
 	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
 	Options    map[string]string           // Options holds the network specific options to use for when creating the network
 	Labels     map[string]string           // Labels holds metadata specific to the network being created
@@ -477,6 +478,7 @@ type NetworkCreate struct {
 	EnableIPv6     bool
 	IPAM           network.IPAM
 	Internal       bool
+	Attachable     bool
 	Options        map[string]string
 	Labels         map[string]string
 }


### PR DESCRIPTION
With this change NetworkAttachmentConfig moves to TaskSpec. We will
continue to support setting the NetworkAttachmentConfig in ServiceSpec
in addition to supporting it in TaskSpec.

Also added `Attachable` flag to NetworkCreateRequest and
NetworkResource types.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>