### PR TITLE
add ContainerUpdateResponse in update api

### DIFF
--- a/client/container_update.go
+++ b/client/container_update.go
@@ -1,13 +1,23 @@
 package client
 
 import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"golang.org/x/net/context"
 )
 
 // ContainerUpdate updates resources of a container
-func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
-	ensureReaderClosed(resp)
-	return err
+func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error) {
+	var response types.ContainerUpdateResponse
+	serverResp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+
+	ensureReaderClosed(serverResp)
+	return response, err
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -56,7 +56,7 @@ type ContainerAPIClient interface {
 	ContainerStop(ctx context.Context, container string, timeout *time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
-	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error
+	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) (types.ContainerUpdateResponse, error)
 	ContainerWait(ctx context.Context, container string) (int, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error


### PR DESCRIPTION
I found that in types.go, ContainerUpdateResponse is defined with `Warnings`fileds like below:
```
type ContainerUpdateResponse struct {
	// Warnings are any warnings encountered during the updating of the container.
	Warnings []string `json:"Warnings"`
}
```
While in the api request, this struct is not used.

As a result, currently docker engine can not use `Warnings` in update api response.

This PR update this missing part in update api response.

Signed-off-by: allencloud <allen.sun@daocloud.io>