### PR TITLE
Fix CI for go1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@
   notifications:
     email: false
   go:
-    - 1.6
+    - 1.7
   install: make deps
   script: make validate && make test

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/engine-api/client/transport"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/go-connections/sockets"
 	"golang.org/x/net/context"
@@ -135,9 +136,8 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 	// from the hostname we're connecting to.
 	if config.ServerName == "" {
 		// Make a copy to avoid polluting argument or default.
-		c := *config
-		c.ServerName = hostname
-		config = &c
+		config = transport.TLSConfigClone(config)
+		config.ServerName = hostname
 	}
 
 	conn := tls.Client(rawConn, config)

--- a/client/transport/tlsconfig_clone.go
+++ b/client/transport/tlsconfig_clone.go
@@ -1,0 +1,11 @@
+// +build !go1.7
+
+package transport
+
+import "crypto/tls"
+
+// TLSConfigClone returns a clone of tls.Config. This function is provided for
+// compatibility for go1.7 that doesn't include this method in stdlib.
+func TLSConfigClone(c *tls.Config) *tls.Config {
+	return c.Clone()
+}

--- a/client/transport/tlsconfig_clone_go17.go
+++ b/client/transport/tlsconfig_clone_go17.go
@@ -1,0 +1,33 @@
+// +build go1.7
+
+package transport
+
+import "crypto/tls"
+
+// TLSConfigClone returns a clone of tls.Config. This function is provided for
+// compatibility for go1.7 that doesn't include this method in stdlib.
+func TLSConfigClone(c *tls.Config) *tls.Config {
+	return &tls.Config{
+		Rand:                        c.Rand,
+		Time:                        c.Time,
+		Certificates:                c.Certificates,
+		NameToCertificate:           c.NameToCertificate,
+		GetCertificate:              c.GetCertificate,
+		RootCAs:                     c.RootCAs,
+		NextProtos:                  c.NextProtos,
+		ServerName:                  c.ServerName,
+		ClientAuth:                  c.ClientAuth,
+		ClientCAs:                   c.ClientCAs,
+		InsecureSkipVerify:          c.InsecureSkipVerify,
+		CipherSuites:                c.CipherSuites,
+		PreferServerCipherSuites:    c.PreferServerCipherSuites,
+		SessionTicketsDisabled:      c.SessionTicketsDisabled,
+		SessionTicketKey:            c.SessionTicketKey,
+		ClientSessionCache:          c.ClientSessionCache,
+		MinVersion:                  c.MinVersion,
+		MaxVersion:                  c.MaxVersion,
+		CurvePreferences:            c.CurvePreferences,
+		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
+		Renegotiation:               c.Renegotiation,
+	}
+}


### PR DESCRIPTION
govet detected a case where we copy tls.Config although
the var contains mutexes. This is fixed in go1.8 with a
stdlib Clone method. Temporarily add a local copy of that 
function until we can move to go1.8 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>