### PR TITLE
ensure transport.Client be closed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -106,7 +106,7 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 // especially needed while using NewClient with *http.Client = nil
 // for example
 // client.NewClient("unix:///var/run/docker.sock", nil, "v1.18", map[string]string{"User-Agent": "engine-api-cli-1.0"})
-func (cli *Client) Close()  {
+func (cli *Client) Close() {
 	cli.transport.Close()
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -102,6 +102,14 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 	}, nil
 }
 
+// ensure transport.Client be closed
+// especially needed while using NewClient with *http.Client = nil
+// for example
+// client.NewClient("unix:///var/run/docker.sock", nil, "v1.18", map[string]string{"User-Agent": "engine-api-cli-1.0"})
+func (cli *Client) Close()  {
+	cli.transport.Close()
+}
+
 // getAPIPath returns the versioned request path to call the api.
 // It appends the query parameters to the path if they are not empty.
 func (cli *Client) getAPIPath(p string, query url.Values) string {

--- a/client/client.go
+++ b/client/client.go
@@ -102,7 +102,7 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 	}, nil
 }
 
-// ensure transport.Client be closed
+// Close ensure transport.Client be closed
 // especially needed while using NewClient with *http.Client = nil
 // for example
 // client.NewClient("unix:///var/run/docker.sock", nil, "v1.18", map[string]string{"User-Agent": "engine-api-cli-1.0"})

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -46,6 +46,10 @@ func (m mockClient) Do(req *http.Request) (*http.Response, error) {
 	return m.do(req)
 }
 
+func (m mockClient) Close() {
+	// do nothing
+}
+
 func errorMock(statusCode int, message string) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		header := http.Header{}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -129,6 +129,8 @@ func TestGetAPIPath(t *testing.T) {
 		if g != cs.e {
 			t.Fatalf("Expected %s, got %s", cs.e, g)
 		}
+
+		c.Close()
 	}
 }
 

--- a/client/transport/client.go
+++ b/client/transport/client.go
@@ -21,6 +21,8 @@ type Client interface {
 	Scheme() string
 	// TLSConfig returns any TLS configuration the client uses.
 	TLSConfig() *tls.Config
+
+	Close()
 }
 
 // tlsInfo returns information about the TLS configuration.

--- a/client/transport/transport.go
+++ b/client/transport/transport.go
@@ -46,6 +46,11 @@ func (a *apiTransport) CancelRequest(req *http.Request) {
 	a.transport.CancelRequest(req)
 }
 
+// ensure transport be closed
+func (a *apiTransport) Close() {
+	a.transport.CloseIdleConnections();
+}
+
 // defaultTransport creates a new http.Transport with Docker's
 // default transport configuration.
 func defaultTransport(proto, addr string) *http.Transport {


### PR DESCRIPTION
ensure transport.Client be closed
especially needed while using cli.NewClient with *http.Client = nil
for example
```golang 
client.NewClient("unix:///var/run/docker.sock", nil, "v1.18", map[string]string{"User-Agent": "engine-api-cli-1.0"})
```